### PR TITLE
feat(optimus): add flag to skip optimus assets compilation on CompileAssetsResponse

### DIFF
--- a/odpf/optimus/plugins/cli.proto
+++ b/odpf/optimus/plugins/cli.proto
@@ -118,4 +118,5 @@ message CompileAssetsRequest {
 }
 message CompileAssetsResponse {
     Assets assets = 1;
+    bool skip_compile = 2;
 }


### PR DESCRIPTION
Prerequisite for https://github.com/odpf/optimus/issues/74 