### PR TITLE
feat: add common service with version endpoint to expose version and other info of the server

### DIFF
--- a/odpf/common/v1/service.proto
+++ b/odpf/common/v1/service.proto
@@ -14,7 +14,7 @@ option java_outer_classname = "CommonServiceProto";
 
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     info: {
-        version: "0.1";
+        version: "0.1.0";
     };
     external_docs: {
         description: "Common endpoints for all services";
@@ -25,22 +25,25 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 service CommonService {
     rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
         option (google.api.http) = {
-            get: "/v1/version"
+            post: "/v1/version"
+            body: "*"
         };
     }
 }
 
-message GetVersionRequest {}
+message GetVersionRequest {
+    Version client = 1;
+}
 
-// Keeping a response envelope over version to add more info in future like latest: bool, latestVersion: Version etc
 message GetVersionResponse {
-    Version version = 1;
+    Version server = 1;
 }
 
 message Version {
     string version = 1;
-    string commit_id = 2;
+    string commit = 2;
     google.protobuf.Timestamp build_time = 3;
     string lang_version = 4;
-    string os_arch = 5;
+    string os = 5;
+    string architechture = 6;
 }

--- a/odpf/common/v1/service.proto
+++ b/odpf/common/v1/service.proto
@@ -45,5 +45,5 @@ message Version {
     google.protobuf.Timestamp build_time = 3;
     string lang_version = 4;
     string os = 5;
-    string architechture = 6;
+    string architecture = 6;
 }

--- a/odpf/common/v1/service.proto
+++ b/odpf/common/v1/service.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package odpf.common.v1;
+
+import "protoc-gen-openapiv2/options/annotations.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/odpf/proton/common/v1";
+option java_multiple_files = true;
+option java_package = "io.odpf.proton.common";
+option java_outer_classname = "CommonServiceProto";
+
+
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+    info: {
+        version: "0.1";
+    };
+    external_docs: {
+        description: "Common endpoints for all services";
+    }
+    schemes: HTTP;
+};
+
+service CommonService {
+    rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
+        option (google.api.http) = {
+            get: "/v1/version"
+        };
+    }
+}
+
+message GetVersionRequest {}
+
+// Keeping a response envelope over version to add more info in future like latest: bool, latestVersion: Version etc
+message GetVersionResponse {
+    Version version = 1;
+}
+
+message Version {
+    string version = 1;
+    string commit_id = 2;
+    google.protobuf.Timestamp build_time = 3;
+    string lang_version = 4;
+    string os_arch = 5;
+}


### PR DESCRIPTION
The purpose of this service is to act as a common way to expose version and build info of our services.
This will also house other common endpoints such as one to get server configurations.