### PR TITLE
feat: remove (soft) resources from db for deleted actual resources in the provider

### DIFF
--- a/odpf/guardian/guardian.proto
+++ b/odpf/guardian/guardian.proto
@@ -72,7 +72,7 @@ service GuardianService {
 
     rpc ListResources(ListResourcesRequest) returns (ListResourcesResponse) {
         option (google.api.http) = {
-            get: "/resources/{is_deleted}"
+            get: "/resources"
         };
     }
 

--- a/odpf/guardian/guardian.proto
+++ b/odpf/guardian/guardian.proto
@@ -72,7 +72,7 @@ service GuardianService {
 
     rpc ListResources(ListResourcesRequest) returns (ListResourcesResponse) {
         option (google.api.http) = {
-            get: "/resources"
+            get: "/resources/{is_deleted}"
         };
     }
 
@@ -196,7 +196,9 @@ message UpdatePolicyResponse {
     Policy policy = 1;
 }
 
-message ListResourcesRequest {}
+message ListResourcesRequest {
+    bool is_deleted = 1;
+}
 
 message ListResourcesResponse {
     repeated Resource resources = 1;
@@ -432,4 +434,5 @@ message Resource {
     map<string, string> labels = 8;
     google.protobuf.Timestamp created_at = 9;
     google.protobuf.Timestamp updated_at = 10;
+    bool is_deleted = 11;
 }


### PR DESCRIPTION
Changes with respect to this feature: https://github.com/odpf/guardian/pull/54