### PR TITLE
feat!: add/modify stencil APIs

### DIFF
--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -2,9 +2,8 @@ syntax = "proto3";
 package odpf.stencil.v1;
 
 import "google/api/annotations.proto";
-import "google/api/field_behavior.proto";
-import "google/api/empty.proto";
 import "google/protobuf/descriptor.proto";
+import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 
@@ -19,7 +18,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 };
 
 service StencilService {
-	rpc ListNamespace(google.protobuf.Empty) returns (ListNamespaceResponse) {
+	rpc ListNamespace(ListNamespaceRequest) returns (ListNamespaceResponse) {
 		option (google.api.http) = {
 			get: "/v1/namespaces"
 		};
@@ -93,7 +92,7 @@ service StencilService {
       summary: "Update only schema metadata";
     };
 	}
-	rpc DeleteSchemas(DeleteSchemasRequest) returns (google.protobuf.Empty) {
+	rpc DeleteSchemas(DeleteSchemasRequest) returns (DeleteSchemasResponse) {
 		option (google.api.http) = {
 			delete: "/v1/namespaces/{id}/schemas"
 		};
@@ -183,6 +182,8 @@ message Version {
 	string id = 2;
 	google.protobuf.Timestamp created_at = 3;
 }
+
+message ListNamespaceRequest {}
 
 message ListNamespaceResponse {
 	repeated string namespaces = 1;

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -85,7 +85,7 @@ service StencilService {
   }
   rpc UpdateSchemaMetadata(UpdateSchemaMetadataRequest) returns (UpdateSchemaMetadataResponse) {
     option (google.api.http) = {
-      patch: "/v1/namespaces/{id}/schemas/{schema_id}"
+      patch: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -130,7 +130,7 @@ service StencilService {
       summary: "List all version numbers for schema";
     };
   }
-  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
+  rpc GetVersionedSchema(GetVersionRequest) returns (GetVersionResponse) {
     option (google.api.http) = {
       get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
     };
@@ -255,8 +255,10 @@ message CreateSchemaResponse {
 }
 
 message UpdateSchemaMetadataRequest {
-  Schema.Format format = 1;
-  string description = 2;
+  string namespace_id = 1;
+  string schema_id = 2;
+  Schema.Format format = 3;
+  string description = 4;
 }
 
 message UpdateSchemaMetadataResponse {
@@ -264,7 +266,8 @@ message UpdateSchemaMetadataResponse {
 }
 
 message DeleteSchemaRequest {
-  string id = 1;
+  string namespace_id = 1;
+  string schema_id = 2;
 }
 
 message DeleteSchemaResponse {

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -17,126 +17,9 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   };
   schemes: HTTP;
 };
+
 service StencilService {
-	rpc UploadDescriptor (UploadDescriptorRequest) returns (UploadDescriptorResponse) {
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-			consumes: "multipart/form-data";
-			produces: "application/json";
-		};
-	}
-	rpc DownloadDescriptor (DownloadDescriptorRequest) returns (DownloadDescriptorResponse) {
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-			produces: "application/octet-stream";
-		};
-	}
-	rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse) {
-		option (google.api.http) = {
-			get: "/v1/snapshots"
-		};
-	}
-	// PromoteSnapshot promotes particular snapshot version as latest
-	rpc PromoteSnapshot(PromoteSnapshotRequest) returns (PromoteSnapshotResponse) {
-		option (google.api.http) = {
-			patch: "/v1/snapshots/{id}/promote"
-		};
-	}
-	// Search matches given query with message names and field names
-	// returns filtered message/field names along with snapshot details
-	rpc Search(SearchRequest) returns (SearchResponse) {
-		option (google.api.http) = {
-			get: "/v1/search"
-		};
-	}
-}
-
-enum Rule {
-	UNKNOWN = 0;
-	FILE_NO_BREAKING_CHANGE = 1;
-	MESSAGE_NO_DELETE = 2;
-	FIELD_NO_BREAKING_CHANGE = 3;
-	ENUM_NO_BREAKING_CHANGE = 4;
-}
-
-message Snapshot {
-	int64 id = 1;
-	string namespace = 2 [(google.api.field_behavior) = REQUIRED];
-	string name = 3;
-	string version = 4;
-	bool latest = 5;
-}
-
-message DownloadDescriptorRequest {
-	string namespace = 1 [(google.api.field_behavior) = REQUIRED];
-	string name = 2 [(google.api.field_behavior) = REQUIRED];
-	string version = 3 [(google.api.field_behavior) = REQUIRED];
-	repeated string fullnames = 4;
-}
-
-message DownloadDescriptorResponse {
-	bytes data = 1;
-}
-
-message UploadDescriptorRequest {
-	string namespace = 1 [(google.api.field_behavior) = REQUIRED];
-	string name = 2 [(google.api.field_behavior) = REQUIRED];
-	string version = 3 [(google.api.field_behavior) = REQUIRED];
-	bytes data = 4 [(google.api.field_behavior) = REQUIRED];
-	bool latest = 5;
-	bool dryrun = 6;
-	Checks checks = 7;
-}
-
-message Checks {
-	repeated Rule except = 2;
-}
-
-message UploadDescriptorResponse {
-	bool success = 1;
-	bool dryrun = 2;
-	string errors = 3;
-}
-
-message ListSnapshotsRequest {
-	string namespace = 1;
-	string name = 2;
-	string version = 3;
-	bool latest = 4;
-}
-
-message ListSnapshotsResponse {
-	repeated Snapshot snapshots = 1;
-}
-
-message SearchRequest {
-	string namespace = 1;
-	string name = 2;
-	string version = 3;
-	bool latest = 4;
-	string query = 5;
-}
-
-message SearchResult {
-	string path = 1;
-	string package = 2;
-	repeated string messages = 3;
-	repeated string fields = 4;
-	repeated Snapshot snapshots = 5;
-}
-
-message SearchResponse {
-	repeated SearchResult results = 1;
-}
-
-message PromoteSnapshotRequest {
-	int64 id = 1;
-}
-
-message PromoteSnapshotResponse {
-	Snapshot snapshot = 1;
-}
-
-service StencilServiceV1 {
-  rpc ListNamespaces(ListNamespaceRequest) returns (ListNamespaceResponse) {
+  rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse) {
     option (google.api.http) = {
       get: "/v1/namespaces"
     };
@@ -200,7 +83,16 @@ service StencilServiceV1 {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
-      summary: "Create schema under the namespace";
+      summary: "Create schema under the namespace. Returns version number, unique ID and location";
+    };
+  }
+  rpc GetSchemaMetadata(GetSchemaMetadataRequest) returns (GetSchemaMetadataResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/meta"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      summary: "Create schema under the namespace. Returns version number, unique ID and location";
     };
   }
   rpc UpdateSchemaMetadata(UpdateSchemaMetadataRequest) returns (UpdateSchemaMetadataResponse) {
@@ -213,16 +105,7 @@ service StencilServiceV1 {
       summary: "Update only schema metadata";
     };
   }
-  rpc DeleteSchemas(DeleteSchemasRequest) returns (DeleteSchemasResponse) {
-    option (google.api.http) = {
-      delete: "/v1/namespaces/{id}/schemas"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "schema";
-      summary: "Delete all schemas under specified namespace";
-    };
-  }
-  rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {
+  rpc GetLatestSchema(GetLatestSchemaRequest) returns (GetLatestSchemaResponse) {
     option (google.api.http) = {
       get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
     };
@@ -241,6 +124,16 @@ service StencilServiceV1 {
       summary: "Delete specified schema";
     };
   }
+  rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      tags: "version";
+      summary: "Get schema for specified version";
+    };
+  }
   rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse) {
     option (google.api.http) = {
       get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions"
@@ -249,16 +142,6 @@ service StencilServiceV1 {
       tags: "schema";
       tags: "version";
       summary: "List all version numbers for schema";
-    };
-  }
-  rpc GetVersionedSchema(GetVersionRequest) returns (GetVersionResponse) {
-    option (google.api.http) = {
-      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "schema";
-      tags: "version";
-      summary: "Get schema for specified version";
     };
   }
   rpc DeleteVersion(DeleteVersionRequest) returns (DeleteVersionResponse) {
@@ -283,22 +166,26 @@ message Namespace {
 
 message Schema {
   enum Format {
-    UNKNOWN = 0;
-    PROTOBUF = 1;
-    AVRO = 2;
-    JSON = 3;
+    FORMAT_UNSPECIFIED = 0;
+    FORMAT_PROTOBUF = 1;
+    FORMAT_AVRO = 2;
+    FORMAT_JSON = 3;
   }
-  string id = 1;
+  enum Compatibility {
+    COMPATIBILITY_UNSPECIFIED = 0;
+    COMPATIBILITY_FULL = 1;
+  }
+  string name = 1;
   Format format = 2;
   string authority = 3;
-  string description = 4;
+  Compatibility compatibility = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
 }
 
-message ListNamespaceRequest {}
+message ListNamespacesRequest {}
 
-message ListNamespaceResponse {
+message ListNamespacesResponse {
   repeated string namespaces = 1;
 }
 
@@ -311,8 +198,8 @@ message GetNamespaceResponse {
 }
 
 message CreateNamespaceRequest {
-  string id = 1;
-  Schema.Format format = 2;
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
+  Schema.Format format = 2 [(google.api.field_behavior) = REQUIRED];
   string description = 3;
 }
 
@@ -322,7 +209,7 @@ message CreateNamespaceResponse {
 
 message UpdateNamespaceRequest {
   string id = 1;
-  Schema.Format format = 2;
+  Schema.Format format = 2 [(google.api.field_behavior) = REQUIRED];
   string description = 3;
 }
 
@@ -344,48 +231,50 @@ message ListSchemasResponse {
   repeated string schemas = 1;
 }
 
-message DeleteSchemasRequest {
-  string id = 1;
-}
-
-message DeleteSchemasResponse {
-  string message = 1;
-}
-
-message GetSchemaRequest {
+message GetLatestSchemaRequest {
   string namespace_id = 1;
   string schema_id = 2;
 }
 
-message GetSchemaResponse {
-  int64 version = 1;
-  Schema.Format format = 2;
+message GetLatestSchemaResponse {
   bytes data = 3;
 }
 
 message CreateSchemaRequest {
   string namespace_id = 1;
   string schema_id = 2;
-  // can be used to override the namespace level format
-  Schema.Format format = 3;
-  string authority = 4;
-  string description = 5;
-  bytes data = 6;
+  bytes data = 3 [(google.api.field_behavior) = REQUIRED];
+  Schema.Format format = 4;
+  Schema.Compatibility compatibility = 5;
 }
 
 message CreateSchemaResponse {
-  Schema schema = 1;
+  int32 version = 1;
+  string id = 2;
+  string location = 3;
+}
+
+message GetSchemaMetadataRequest {
+  string namespace_id = 1;
+  string schema_id = 2;
+}
+
+message GetSchemaMetadataResponse {
+  Schema.Format format = 1;
+  Schema.Compatibility compatibility = 2;
+  string authority = 3;
 }
 
 message UpdateSchemaMetadataRequest {
   string namespace_id = 1;
   string schema_id = 2;
-  Schema.Format format = 3;
-  string description = 4;
+  Schema.Compatibility compatibility = 3;
 }
 
 message UpdateSchemaMetadataResponse {
-  Schema schema = 1;
+  Schema.Format format = 1;
+  Schema.Compatibility compatibility = 2;
+  string authority = 3;
 }
 
 message DeleteSchemaRequest {
@@ -403,23 +292,23 @@ message ListVersionsRequest {
 }
 
 message ListVersionsResponse {
-  repeated int64 versions = 1;
+  repeated int32 versions = 1;
 }
 
-message GetVersionRequest {
+message GetSchemaRequest {
   string namespace_id = 1;
   string schema_id = 2;
-  string version_id = 3;
+  int32 version_id = 3;
 }
 
-message GetVersionResponse {
+message GetSchemaResponse {
   bytes data = 1;
 }
 
 message DeleteVersionRequest {
   string namespace_id = 1;
   string schema_id = 2;
-  string version_id = 3;
+  int32 version_id = 3;
 }
 
 message DeleteVersionResponse {

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package odpf.stencil.v1;
 
 import "google/api/annotations.proto";
+import "google/api/field_behavior.proto";
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -16,8 +17,125 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   };
   schemes: HTTP;
 };
-
 service StencilService {
+	rpc UploadDescriptor (UploadDescriptorRequest) returns (UploadDescriptorResponse) {
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+			consumes: "multipart/form-data";
+			produces: "application/json";
+		};
+	}
+	rpc DownloadDescriptor (DownloadDescriptorRequest) returns (DownloadDescriptorResponse) {
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+			produces: "application/octet-stream";
+		};
+	}
+	rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse) {
+		option (google.api.http) = {
+			get: "/v1/snapshots"
+		};
+	}
+	// PromoteSnapshot promotes particular snapshot version as latest
+	rpc PromoteSnapshot(PromoteSnapshotRequest) returns (PromoteSnapshotResponse) {
+		option (google.api.http) = {
+			patch: "/v1/snapshots/{id}/promote"
+		};
+	}
+	// Search matches given query with message names and field names
+	// returns filtered message/field names along with snapshot details
+	rpc Search(SearchRequest) returns (SearchResponse) {
+		option (google.api.http) = {
+			get: "/v1/search"
+		};
+	}
+}
+
+enum Rule {
+	UNKNOWN = 0;
+	FILE_NO_BREAKING_CHANGE = 1;
+	MESSAGE_NO_DELETE = 2;
+	FIELD_NO_BREAKING_CHANGE = 3;
+	ENUM_NO_BREAKING_CHANGE = 4;
+}
+
+message Snapshot {
+	int64 id = 1;
+	string namespace = 2 [(google.api.field_behavior) = REQUIRED];
+	string name = 3;
+	string version = 4;
+	bool latest = 5;
+}
+
+message DownloadDescriptorRequest {
+	string namespace = 1 [(google.api.field_behavior) = REQUIRED];
+	string name = 2 [(google.api.field_behavior) = REQUIRED];
+	string version = 3 [(google.api.field_behavior) = REQUIRED];
+	repeated string fullnames = 4;
+}
+
+message DownloadDescriptorResponse {
+	bytes data = 1;
+}
+
+message UploadDescriptorRequest {
+	string namespace = 1 [(google.api.field_behavior) = REQUIRED];
+	string name = 2 [(google.api.field_behavior) = REQUIRED];
+	string version = 3 [(google.api.field_behavior) = REQUIRED];
+	bytes data = 4 [(google.api.field_behavior) = REQUIRED];
+	bool latest = 5;
+	bool dryrun = 6;
+	Checks checks = 7;
+}
+
+message Checks {
+	repeated Rule except = 2;
+}
+
+message UploadDescriptorResponse {
+	bool success = 1;
+	bool dryrun = 2;
+	string errors = 3;
+}
+
+message ListSnapshotsRequest {
+	string namespace = 1;
+	string name = 2;
+	string version = 3;
+	bool latest = 4;
+}
+
+message ListSnapshotsResponse {
+	repeated Snapshot snapshots = 1;
+}
+
+message SearchRequest {
+	string namespace = 1;
+	string name = 2;
+	string version = 3;
+	bool latest = 4;
+	string query = 5;
+}
+
+message SearchResult {
+	string path = 1;
+	string package = 2;
+	repeated string messages = 3;
+	repeated string fields = 4;
+	repeated Snapshot snapshots = 5;
+}
+
+message SearchResponse {
+	repeated SearchResult results = 1;
+}
+
+message PromoteSnapshotRequest {
+	int64 id = 1;
+}
+
+message PromoteSnapshotResponse {
+	Snapshot snapshot = 1;
+}
+
+service StencilServiceV1 {
   rpc ListNamespace(ListNamespaceRequest) returns (ListNamespaceResponse) {
     option (google.api.http) = {
       get: "/v1/namespaces"

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -3,11 +3,12 @@ package odpf.stencil.v1;
 
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
+import "google/api/empty.proto";
 import "google/protobuf/descriptor.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 
-option go_package = "github.com/odpf/proton/stencil/v1;stencilv1";
+option go_package = "github.com/odpf/proton/stencil/v1beta1;stencilv1beta1";
 
 // These annotations are used when generating the OpenAPI file.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
@@ -18,119 +19,289 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 };
 
 service StencilService {
-	rpc UploadDescriptor (UploadDescriptorRequest) returns (UploadDescriptorResponse) {
+	rpc ListNamespace(google.protobuf.Empty) returns (ListNamespaceResponse) {
+		option (google.api.http) = {
+			get: "/v1/namespaces"
+		};
 		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-			consumes: "multipart/form-data";
-			produces: "application/json";
-		};
+      tags: "namespace";
+      summary: "List names of namespaces";
+    };
 	}
-	rpc DownloadDescriptor (DownloadDescriptorRequest) returns (DownloadDescriptorResponse) {
+	rpc GetNamespace(GetNamespaceRequest) returns (GetNamespaceResponse) {
+		option (google.api.http) = {
+			get: "/v1/namespaces/{id}"
+		};
 		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-			produces: "application/octet-stream";
-		};
+      tags: "namespace";
+      summary: "Get namespace by id";
+    };
 	}
-	rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse) {
+	rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse) {
 		option (google.api.http) = {
-			get: "/v1/snapshots"
+			post: "/v1/namespaces",
+			body: "*"
 		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "namespace";
+      summary: "Create namespace entry";
+    };
 	}
-	// PromoteSnapshot promotes particular snapshot version as latest
-	rpc PromoteSnapshot(PromoteSnapshotRequest) returns (PromoteSnapshotResponse) {
+	rpc UpdateNamespace(UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
 		option (google.api.http) = {
-			patch: "/v1/snapshots/{id}/promote"
+			put: "/v1/namespaces/{id}"
 		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "namespace";
+      summary: "Update namespace entity by id";
+    };
 	}
-	// Search matches given query with message names and field names
-	// returns filtered message/field names along with snapshot details
-	rpc Search(SearchRequest) returns (SearchResponse) {
+	rpc DeleteNamespace(DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
 		option (google.api.http) = {
-			get: "/v1/search"
+			delete: "/v1/namespaces/{id}"
 		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "namespace";
+      summary: "Delete namespace by id";
+			description: "Ensure all schemas under this namespace is deleted, otherwise it will throw error";
+    };
+	}
+	rpc ListSchemas(ListSchemasRequest) returns (ListSchemasResponse) {
+		option (google.api.http) = {
+			get: "/v1/namespaces/{id}/schemas"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      summary: "List schemas under the namespace";
+    };
+	}
+	rpc CreateSchema(CreateSchemaRequest) returns (CreateSchemaResponse) {
+		option (google.api.http) = {
+			post: "/v1/namespaces/{id}/schemas/{schema_id}"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      summary: "Create schema under the namespace";
+    };
+	}
+	rpc UpdateSchemaMetadata(UpdateSchemaMetadataRequest) returns (UpdateSchemaMetadataResponse) {
+		option (google.api.http) = {
+			patch: "/v1/namespaces/{id}/schemas/{schema_id}"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      summary: "Update only schema metadata";
+    };
+	}
+	rpc DeleteSchemas(DeleteSchemasRequest) returns (google.protobuf.Empty) {
+		option (google.api.http) = {
+			delete: "/v1/namespaces/{id}/schemas"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      summary: "Delete all schemas under specified namespace";
+    };
+	}
+	rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {
+		option (google.api.http) = {
+			get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      summary: "Get latest schema for specified schema id and namespace id";
+			description: "Returns schema data in byte64 format. Clients can decode 'data' field to expected data format"
+    };
+	}
+	rpc DeleteSchema(DeleteSchemaRequest) returns (DeleteSchemaResponse) {
+		option (google.api.http) = {
+			delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+      summary: "Delete specified schema";
+    };
+	}
+	rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse) {
+		option (google.api.http) = {
+			get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
+			tags: "version";
+      summary: "List all version numbers for schema";
+    };
+	}
+	rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
+		option (google.api.http) = {
+			get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+			tags: "schema";
+      tags: "version";
+      summary: "Get schema for specified version";
+    };
+	}
+	rpc DeleteVersion(DeleteVersionRequest) returns (DeleteVersionResponse) {
+		option (google.api.http) = {
+			delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
+		};
+		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+			tags: "schema";
+      tags: "version";
+      summary: "Delete specified version of the schema";
+    };
 	}
 }
 
-enum Rule {
-	UNKNOWN = 0;
-	FILE_NO_BREAKING_CHANGE = 1;
-	MESSAGE_NO_DELETE = 2;
-	FIELD_NO_BREAKING_CHANGE = 3;
-	ENUM_NO_BREAKING_CHANGE = 4;
+message Namespace {
+	string id = 1;
+	Schema.Format format = 2;
+	string description = 3;
+	google.protobuf.Timestamp created_at = 4;
+	google.protobuf.Timestamp updated_at = 5;
 }
 
-message Snapshot {
-	int64 id = 1;
-	string namespace = 2 [(google.api.field_behavior) = REQUIRED];
-	string name = 3;
-	string version = 4;
-	bool latest = 5;
+message Schema {
+	enum Format {
+		UNKNOWN = 0;
+		PROTOBUF = 1;
+		AVRO = 2;
+		JSON = 3;
+	}
+	string id = 1;
+	Format format = 2;
+	string authority = 3;
+	string description = 4;
+	google.protobuf.Timestamp created_at = 5;
+	google.protobuf.Timestamp updated_at = 6;
 }
 
-message DownloadDescriptorRequest {
-	string namespace = 1 [(google.api.field_behavior) = REQUIRED];
-	string name = 2 [(google.api.field_behavior) = REQUIRED];
-	string version = 3 [(google.api.field_behavior) = REQUIRED];
-	repeated string fullnames = 4;
+message Version {
+	// auto increment version number
+	int64 version = 1;
+	// unique id, used to globally refer to this version
+	string id = 2;
+	google.protobuf.Timestamp created_at = 3;
 }
 
-message DownloadDescriptorResponse {
+message ListNamespaceResponse {
+	repeated string namespaces = 1;
+}
+
+message GetNamespaceRequest {
+	string id = 1;
+}
+
+message GetNamespaceResponse {	
+	Namespace namespace = 1;
+}
+
+message CreateNamespaceRequest {
+	string id = 1;
+	Schema.Format format = 2;
+	string description = 3;
+}
+
+message CreateNamespaceResponse {
+	Namespace namespace = 1;
+}
+
+message UpdateNamespaceRequest {
+	string id = 1;
+}
+
+message UpdateNamespaceResponse {
+	Namespace namespace = 1;
+}
+
+message DeleteNamespaceRequest {
+	string id = 1;
+}
+message DeleteNamespaceResponse {
+	string message = 1;
+}
+
+message ListSchemasRequest {
+	string id = 1;
+}
+message ListSchemasResponse {
+	repeated string schemas = 1;
+}
+
+message DeleteSchemasRequest {
+	string id = 1;
+}
+
+message DeleteSchemasResponse {
+	string message = 1;
+}
+
+message GetSchemaRequest {
+	string namespace_id = 1;
+	string schema_id = 2;
+}
+
+message GetSchemaResponse {
+	int64 version = 1;
+	Schema.Format format = 2;
+	bytes data = 3;
+}
+
+message CreateSchemaRequest {
+	string namespace_id = 1;
+	string schema_id = 2;
+	// can be used to override the namespace level format
+	Schema.Format format = 3;
+	string authority = 4;
+	string description = 5;
+}
+
+message CreateSchemaResponse {
+	Schema schema = 1;
+}
+
+message UpdateSchemaMetadataRequest {
+	Schema.Format format = 1;
+	string description = 2;
+}
+
+message UpdateSchemaMetadataResponse {
+	Schema schema = 1;
+}
+
+message DeleteSchemaRequest {
+	string id = 1;
+}
+
+message DeleteSchemaResponse {
+	string message = 1;
+}
+
+message ListVersionsRequest {
+	string namespace_id = 1;
+	string schema_id = 2;
+}
+
+message ListVersionsResponse {
+	repeated int64 versions = 1;
+}
+
+message GetVersionRequest {
+	string namespace_id = 1;
+	string schema_id = 2;
+	string version_id = 3;
+}
+
+message GetVersionResponse {
 	bytes data = 1;
 }
 
-message UploadDescriptorRequest {
-	string namespace = 1 [(google.api.field_behavior) = REQUIRED];
-	string name = 2 [(google.api.field_behavior) = REQUIRED];
-	string version = 3 [(google.api.field_behavior) = REQUIRED];
-	bytes data = 4 [(google.api.field_behavior) = REQUIRED];
-	bool latest = 5;
-	bool dryrun = 6;
-	Checks checks = 7;
+message DeleteVersionRequest {
+	string namespace_id = 1;
+	string schema_id = 2;
+	string version_id = 3;
 }
 
-message Checks {
-	repeated Rule except = 2;
-}
-
-message UploadDescriptorResponse {
-	bool success = 1;
-	bool dryrun = 2;
-	string errors = 3;
-}
-
-message ListSnapshotsRequest {
-	string namespace = 1;
-	string name = 2;
-	string version = 3;
-	bool latest = 4;
-}
-
-message ListSnapshotsResponse {
-	repeated Snapshot snapshots = 1;
-}
-
-message SearchRequest {
-	string namespace = 1;
-	string name = 2;
-	string version = 3;
-	bool latest = 4;
-	string query = 5;
-}
-
-message SearchResult {
-	string path = 1;
-	string package = 2;
-	repeated string messages = 3;
-	repeated string fields = 4;
-	repeated Snapshot snapshots = 5;
-}
-
-message SearchResponse {
-	repeated SearchResult results = 1;
-}
-
-message PromoteSnapshotRequest {
-	int64 id = 1;
-}
-
-message PromoteSnapshotResponse {
-	Snapshot snapshot = 1;
+message DeleteVersionResponse {
+	string message = 1;
 }

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -195,7 +195,8 @@ service StencilServiceV1 {
   }
   rpc CreateSchema(CreateSchemaRequest) returns (CreateSchemaResponse) {
     option (google.api.http) = {
-      post: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+      post: "/v1/namespaces/{namespace_id}/schemas/{schema_id}",
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -205,6 +206,7 @@ service StencilServiceV1 {
   rpc UpdateSchemaMetadata(UpdateSchemaMetadataRequest) returns (UpdateSchemaMetadataResponse) {
     option (google.api.http) = {
       patch: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -175,14 +175,6 @@ message Schema {
 	google.protobuf.Timestamp updated_at = 6;
 }
 
-message Version {
-	// auto increment version number
-	int64 version = 1;
-	// unique id, used to globally refer to this version
-	string id = 2;
-	google.protobuf.Timestamp created_at = 3;
-}
-
 message ListNamespaceRequest {}
 
 message ListNamespaceResponse {

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -166,7 +166,8 @@ service StencilServiceV1 {
   }
   rpc UpdateNamespace(UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
     option (google.api.http) = {
-      put: "/v1/namespaces/{id}"
+      put: "/v1/namespaces/{id}",
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
@@ -319,6 +320,8 @@ message CreateNamespaceResponse {
 
 message UpdateNamespaceRequest {
   string id = 1;
+  Schema.Format format = 2;
+  string description = 3;
 }
 
 message UpdateNamespaceResponse {

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -76,7 +76,7 @@ service StencilService {
   }
   rpc CreateSchema(CreateSchemaRequest) returns (CreateSchemaResponse) {
     option (google.api.http) = {
-      post: "/v1/namespaces/{id}/schemas/{schema_id}"
+      post: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -247,6 +247,7 @@ message CreateSchemaRequest {
   Schema.Format format = 3;
   string authority = 4;
   string description = 5;
+  bytes data = 6;
 }
 
 message CreateSchemaResponse {

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -7,7 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 
-option go_package = "github.com/odpf/proton/stencil/v1beta1;stencilv1beta1";
+option go_package = "github.com/odpf/proton/stencil/v1;stencilv1";
 
 // These annotations are used when generating the OpenAPI file.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -11,290 +11,290 @@ option go_package = "github.com/odpf/proton/stencil/v1beta1;stencilv1beta1";
 
 // These annotations are used when generating the OpenAPI file.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
-	info: {
-		version: "0.1.4";
-	};
-	schemes: HTTP;
+  info: {
+    version: "0.1.4";
+  };
+  schemes: HTTP;
 };
 
 service StencilService {
-	rpc ListNamespace(ListNamespaceRequest) returns (ListNamespaceResponse) {
-		option (google.api.http) = {
-			get: "/v1/namespaces"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  rpc ListNamespace(ListNamespaceRequest) returns (ListNamespaceResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
       summary: "List names of namespaces";
     };
-	}
-	rpc GetNamespace(GetNamespaceRequest) returns (GetNamespaceResponse) {
-		option (google.api.http) = {
-			get: "/v1/namespaces/{id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc GetNamespace(GetNamespaceRequest) returns (GetNamespaceResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
       summary: "Get namespace by id";
     };
-	}
-	rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse) {
-		option (google.api.http) = {
-			post: "/v1/namespaces",
-			body: "*"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse) {
+    option (google.api.http) = {
+      post: "/v1/namespaces",
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
       summary: "Create namespace entry";
     };
-	}
-	rpc UpdateNamespace(UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
-		option (google.api.http) = {
-			put: "/v1/namespaces/{id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc UpdateNamespace(UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
+    option (google.api.http) = {
+      put: "/v1/namespaces/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
       summary: "Update namespace entity by id";
     };
-	}
-	rpc DeleteNamespace(DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
-		option (google.api.http) = {
-			delete: "/v1/namespaces/{id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc DeleteNamespace(DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
+    option (google.api.http) = {
+      delete: "/v1/namespaces/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
       summary: "Delete namespace by id";
-			description: "Ensure all schemas under this namespace is deleted, otherwise it will throw error";
+      description: "Ensure all schemas under this namespace is deleted, otherwise it will throw error";
     };
-	}
-	rpc ListSchemas(ListSchemasRequest) returns (ListSchemasResponse) {
-		option (google.api.http) = {
-			get: "/v1/namespaces/{id}/schemas"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc ListSchemas(ListSchemasRequest) returns (ListSchemasResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces/{id}/schemas"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
       summary: "List schemas under the namespace";
     };
-	}
-	rpc CreateSchema(CreateSchemaRequest) returns (CreateSchemaResponse) {
-		option (google.api.http) = {
-			post: "/v1/namespaces/{id}/schemas/{schema_id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc CreateSchema(CreateSchemaRequest) returns (CreateSchemaResponse) {
+    option (google.api.http) = {
+      post: "/v1/namespaces/{id}/schemas/{schema_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
       summary: "Create schema under the namespace";
     };
-	}
-	rpc UpdateSchemaMetadata(UpdateSchemaMetadataRequest) returns (UpdateSchemaMetadataResponse) {
-		option (google.api.http) = {
-			patch: "/v1/namespaces/{id}/schemas/{schema_id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc UpdateSchemaMetadata(UpdateSchemaMetadataRequest) returns (UpdateSchemaMetadataResponse) {
+    option (google.api.http) = {
+      patch: "/v1/namespaces/{id}/schemas/{schema_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
       summary: "Update only schema metadata";
     };
-	}
-	rpc DeleteSchemas(DeleteSchemasRequest) returns (DeleteSchemasResponse) {
-		option (google.api.http) = {
-			delete: "/v1/namespaces/{id}/schemas"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc DeleteSchemas(DeleteSchemasRequest) returns (DeleteSchemasResponse) {
+    option (google.api.http) = {
+      delete: "/v1/namespaces/{id}/schemas"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
       summary: "Delete all schemas under specified namespace";
     };
-	}
-	rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {
-		option (google.api.http) = {
-			get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
       summary: "Get latest schema for specified schema id and namespace id";
-			description: "Returns schema data in byte64 format. Clients can decode 'data' field to expected data format"
+      description: "Returns schema data in byte64 format. Clients can decode 'data' field to expected data format"
     };
-	}
-	rpc DeleteSchema(DeleteSchemaRequest) returns (DeleteSchemaResponse) {
-		option (google.api.http) = {
-			delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc DeleteSchema(DeleteSchemaRequest) returns (DeleteSchemaResponse) {
+    option (google.api.http) = {
+      delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
       summary: "Delete specified schema";
     };
-	}
-	rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse) {
-		option (google.api.http) = {
-			get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+  }
+  rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
-			tags: "version";
+      tags: "version";
       summary: "List all version numbers for schema";
     };
-	}
-	rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
-		option (google.api.http) = {
-			get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-			tags: "schema";
+  }
+  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
+    option (google.api.http) = {
+      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
       tags: "version";
       summary: "Get schema for specified version";
     };
-	}
-	rpc DeleteVersion(DeleteVersionRequest) returns (DeleteVersionResponse) {
-		option (google.api.http) = {
-			delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
-		};
-		option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-			tags: "schema";
+  }
+  rpc DeleteVersion(DeleteVersionRequest) returns (DeleteVersionResponse) {
+    option (google.api.http) = {
+      delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "schema";
       tags: "version";
       summary: "Delete specified version of the schema";
     };
-	}
+  }
 }
 
 message Namespace {
-	string id = 1;
-	Schema.Format format = 2;
-	string description = 3;
-	google.protobuf.Timestamp created_at = 4;
-	google.protobuf.Timestamp updated_at = 5;
+  string id = 1;
+  Schema.Format format = 2;
+  string description = 3;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp updated_at = 5;
 }
 
 message Schema {
-	enum Format {
-		UNKNOWN = 0;
-		PROTOBUF = 1;
-		AVRO = 2;
-		JSON = 3;
-	}
-	string id = 1;
-	Format format = 2;
-	string authority = 3;
-	string description = 4;
-	google.protobuf.Timestamp created_at = 5;
-	google.protobuf.Timestamp updated_at = 6;
+  enum Format {
+    UNKNOWN = 0;
+    PROTOBUF = 1;
+    AVRO = 2;
+    JSON = 3;
+  }
+  string id = 1;
+  Format format = 2;
+  string authority = 3;
+  string description = 4;
+  google.protobuf.Timestamp created_at = 5;
+  google.protobuf.Timestamp updated_at = 6;
 }
 
 message ListNamespaceRequest {}
 
 message ListNamespaceResponse {
-	repeated string namespaces = 1;
+  repeated string namespaces = 1;
 }
 
 message GetNamespaceRequest {
-	string id = 1;
+  string id = 1;
 }
 
 message GetNamespaceResponse {	
-	Namespace namespace = 1;
+  Namespace namespace = 1;
 }
 
 message CreateNamespaceRequest {
-	string id = 1;
-	Schema.Format format = 2;
-	string description = 3;
+  string id = 1;
+  Schema.Format format = 2;
+  string description = 3;
 }
 
 message CreateNamespaceResponse {
-	Namespace namespace = 1;
+  Namespace namespace = 1;
 }
 
 message UpdateNamespaceRequest {
-	string id = 1;
+  string id = 1;
 }
 
 message UpdateNamespaceResponse {
-	Namespace namespace = 1;
+  Namespace namespace = 1;
 }
 
 message DeleteNamespaceRequest {
-	string id = 1;
+  string id = 1;
 }
 message DeleteNamespaceResponse {
-	string message = 1;
+  string message = 1;
 }
 
 message ListSchemasRequest {
-	string id = 1;
+  string id = 1;
 }
 message ListSchemasResponse {
-	repeated string schemas = 1;
+  repeated string schemas = 1;
 }
 
 message DeleteSchemasRequest {
-	string id = 1;
+  string id = 1;
 }
 
 message DeleteSchemasResponse {
-	string message = 1;
+  string message = 1;
 }
 
 message GetSchemaRequest {
-	string namespace_id = 1;
-	string schema_id = 2;
+  string namespace_id = 1;
+  string schema_id = 2;
 }
 
 message GetSchemaResponse {
-	int64 version = 1;
-	Schema.Format format = 2;
-	bytes data = 3;
+  int64 version = 1;
+  Schema.Format format = 2;
+  bytes data = 3;
 }
 
 message CreateSchemaRequest {
-	string namespace_id = 1;
-	string schema_id = 2;
-	// can be used to override the namespace level format
-	Schema.Format format = 3;
-	string authority = 4;
-	string description = 5;
+  string namespace_id = 1;
+  string schema_id = 2;
+  // can be used to override the namespace level format
+  Schema.Format format = 3;
+  string authority = 4;
+  string description = 5;
 }
 
 message CreateSchemaResponse {
-	Schema schema = 1;
+  Schema schema = 1;
 }
 
 message UpdateSchemaMetadataRequest {
-	Schema.Format format = 1;
-	string description = 2;
+  Schema.Format format = 1;
+  string description = 2;
 }
 
 message UpdateSchemaMetadataResponse {
-	Schema schema = 1;
+  Schema schema = 1;
 }
 
 message DeleteSchemaRequest {
-	string id = 1;
+  string id = 1;
 }
 
 message DeleteSchemaResponse {
-	string message = 1;
+  string message = 1;
 }
 
 message ListVersionsRequest {
-	string namespace_id = 1;
-	string schema_id = 2;
+  string namespace_id = 1;
+  string schema_id = 2;
 }
 
 message ListVersionsResponse {
-	repeated int64 versions = 1;
+  repeated int64 versions = 1;
 }
 
 message GetVersionRequest {
-	string namespace_id = 1;
-	string schema_id = 2;
-	string version_id = 3;
+  string namespace_id = 1;
+  string schema_id = 2;
+  string version_id = 3;
 }
 
 message GetVersionResponse {
-	bytes data = 1;
+  bytes data = 1;
 }
 
 message DeleteVersionRequest {
-	string namespace_id = 1;
-	string schema_id = 2;
-	string version_id = 3;
+  string namespace_id = 1;
+  string schema_id = 2;
+  string version_id = 3;
 }
 
 message DeleteVersionResponse {
-	string message = 1;
+  string message = 1;
 }

--- a/odpf/stencil/v1/stencil.proto
+++ b/odpf/stencil/v1/stencil.proto
@@ -136,7 +136,7 @@ message PromoteSnapshotResponse {
 }
 
 service StencilServiceV1 {
-  rpc ListNamespace(ListNamespaceRequest) returns (ListNamespaceResponse) {
+  rpc ListNamespaces(ListNamespaceRequest) returns (ListNamespaceResponse) {
     option (google.api.http) = {
       get: "/v1/namespaces"
     };

--- a/odpf/stencil/v1beta1/stencil.proto
+++ b/odpf/stencil/v1beta1/stencil.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package odpf.stencil.v1;
+package odpf.stencil.v1beta1;
 
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
@@ -8,7 +8,7 @@ import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 
-option go_package = "github.com/odpf/proton/stencil/v1;stencilv1";
+option go_package = "github.com/odpf/proton/stencil/v1beta1;stencilv1beta1";
 
 // These annotations are used when generating the OpenAPI file.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
@@ -21,7 +21,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 service StencilService {
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse) {
     option (google.api.http) = {
-      get: "/v1/namespaces"
+      get: "/v1beta1/namespaces"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
@@ -30,7 +30,7 @@ service StencilService {
   }
   rpc GetNamespace(GetNamespaceRequest) returns (GetNamespaceResponse) {
     option (google.api.http) = {
-      get: "/v1/namespaces/{id}"
+      get: "/v1beta1/namespaces/{id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
@@ -39,7 +39,7 @@ service StencilService {
   }
   rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse) {
     option (google.api.http) = {
-      post: "/v1/namespaces",
+      post: "/v1beta1/namespaces",
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -49,7 +49,7 @@ service StencilService {
   }
   rpc UpdateNamespace(UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
     option (google.api.http) = {
-      put: "/v1/namespaces/{id}",
+      put: "/v1beta1/namespaces/{id}",
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -59,7 +59,7 @@ service StencilService {
   }
   rpc DeleteNamespace(DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
     option (google.api.http) = {
-      delete: "/v1/namespaces/{id}"
+      delete: "/v1beta1/namespaces/{id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "namespace";
@@ -69,7 +69,7 @@ service StencilService {
   }
   rpc ListSchemas(ListSchemasRequest) returns (ListSchemasResponse) {
     option (google.api.http) = {
-      get: "/v1/namespaces/{id}/schemas"
+      get: "/v1beta1/namespaces/{id}/schemas"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -78,7 +78,7 @@ service StencilService {
   }
   rpc CreateSchema(CreateSchemaRequest) returns (CreateSchemaResponse) {
     option (google.api.http) = {
-      post: "/v1/namespaces/{namespace_id}/schemas/{schema_id}",
+      post: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}",
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -88,7 +88,7 @@ service StencilService {
   }
   rpc GetSchemaMetadata(GetSchemaMetadataRequest) returns (GetSchemaMetadataResponse) {
     option (google.api.http) = {
-      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/meta"
+      get: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}/meta"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -97,7 +97,7 @@ service StencilService {
   }
   rpc UpdateSchemaMetadata(UpdateSchemaMetadataRequest) returns (UpdateSchemaMetadataResponse) {
     option (google.api.http) = {
-      patch: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+      patch: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -107,7 +107,7 @@ service StencilService {
   }
   rpc GetLatestSchema(GetLatestSchemaRequest) returns (GetLatestSchemaResponse) {
     option (google.api.http) = {
-      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+      get: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -117,7 +117,7 @@ service StencilService {
   }
   rpc DeleteSchema(DeleteSchemaRequest) returns (DeleteSchemaResponse) {
     option (google.api.http) = {
-      delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}"
+      delete: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -126,7 +126,7 @@ service StencilService {
   }
   rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {
     option (google.api.http) = {
-      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
+      get: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -136,7 +136,7 @@ service StencilService {
   }
   rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse) {
     option (google.api.http) = {
-      get: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions"
+      get: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}/versions"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";
@@ -146,7 +146,7 @@ service StencilService {
   }
   rpc DeleteVersion(DeleteVersionRequest) returns (DeleteVersionResponse) {
     option (google.api.http) = {
-      delete: "/v1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
+      delete: "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}/versions/{version_id}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "schema";


### PR DESCRIPTION
BREAKING CHANGE: Modify existing download and upload APIs
Add new CRUD APIs for each namespace, schema and version entities.
Rename "descriptors" to "schema" in URL path