### PR TITLE
feat(assets): add usage metrics to table profile

### DIFF
--- a/odpf/assets/table.proto
+++ b/odpf/assets/table.proto
@@ -69,13 +69,13 @@ message TableProfile {
 
   int64 usage_count = 4;
   
-  repeated TableCommonJoin common_join = 5;
+  repeated Join joins = 5;
 
-  repeated string filter_conditions = 6;
+  repeated string filters = 6;
 }
 
-// TableCommonJoin is the metric of which are other tables that are joined with this table
-message TableCommonJoin {
+// Join is the metric of which are other tables that are joined with this table
+message Join {
   string urn = 1;
 
   int64 count = 2;

--- a/odpf/assets/table.proto
+++ b/odpf/assets/table.proto
@@ -70,6 +70,8 @@ message TableProfile {
   int64 usage_count = 4;
   
   repeated TableCommonJoin common_join = 5;
+
+  repeated string filter_conditions = 6;
 }
 
 // TableCommonJoin is the metric of which are other tables that are joined with this table
@@ -78,7 +80,5 @@ message TableCommonJoin {
 
   int64 count = 2;
 
-  repeated string join_conditions = 3;
-
-  repeated string filter_conditions = 4;
+  repeated string conditions = 3;
 }

--- a/odpf/assets/table.proto
+++ b/odpf/assets/table.proto
@@ -72,10 +72,13 @@ message TableProfile {
   repeated TableCommonJoin common_join = 5;
 }
 
-// TableCommonJoin is the metric of which are other tables that 
-// are joined with this table
+// TableCommonJoin is the metric of which are other tables that are joined with this table
 message TableCommonJoin {
   string urn = 1;
 
   int64 count = 2;
+
+  repeated string join_conditions = 3;
+
+  repeated string filter_conditions = 4;
 }

--- a/odpf/assets/table.proto
+++ b/odpf/assets/table.proto
@@ -66,4 +66,16 @@ message TableProfile {
   string partition_key = 2;
 
   string partition_value = 3;
+
+  int64 usage_count = 4;
+  
+  repeated TableCommonJoin common_join = 5;
+}
+
+// TableCommonJoin is the metric of which are other tables that 
+// are joined with this table
+message TableCommonJoin {
+  string urn = 1;
+
+  int64 count = 2;
 }


### PR DESCRIPTION
- Add several fields in `assets/table/TableProfile` to store table usage stats
  - Add `usage_count` as a metric for table usage
  - Add `common_join` as a metric for the list of joined tables
- Related [PR](https://github.com/odpf/meteor/pull/271) in meteor