### PR TITLE
feat(guardian): add new endpoint to update one provider by type and urn

### DIFF
--- a/odpf/guardian/v1beta1/guardian.proto
+++ b/odpf/guardian/v1beta1/guardian.proto
@@ -42,7 +42,7 @@ service GuardianService {
             put: "/v1beta1/providers/{id}"
             body: "config"
             additional_bindings: {
-                put: "/v1beta1/providers/{type}/{urn}"
+                put: "/v1beta1/providers/{config.type}/{config.urn}"
                 body: "config"
             }
         };
@@ -182,8 +182,6 @@ message CreateProviderResponse {
 message UpdateProviderRequest {
     string id = 1;
     ProviderConfig config = 2;
-    string type = 3;
-    string urn = 4;
 }
 
 message UpdateProviderResponse {

--- a/odpf/guardian/v1beta1/guardian.proto
+++ b/odpf/guardian/v1beta1/guardian.proto
@@ -41,6 +41,10 @@ service GuardianService {
         option (google.api.http) = {
             put: "/v1beta1/providers/{id}"
             body: "config"
+            additional_bindings: {
+                put: "/v1beta1/providers/{type}/{urn}"
+                body: "config"
+            }
         };
     }
 
@@ -178,6 +182,8 @@ message CreateProviderResponse {
 message UpdateProviderRequest {
     string id = 1;
     ProviderConfig config = 2;
+    string type = 3;
+    string urn = 4;
 }
 
 message UpdateProviderResponse {


### PR DESCRIPTION
need this to accommodate the http endpoints for the change in this guardian PR: https://github.com/odpf/guardian/pull/142