### PR TITLE
feat: Add guardian get provider types request

### DIFF
--- a/odpf/guardian/v1beta1/guardian.proto
+++ b/odpf/guardian/v1beta1/guardian.proto
@@ -431,7 +431,7 @@ message Provider {
 
 message ProviderType {
     string name = 1;
-    repeated string resource_type = 2;
+    repeated string resource_types = 2;
 }
 
 message Condition {

--- a/odpf/guardian/v1beta1/guardian.proto
+++ b/odpf/guardian/v1beta1/guardian.proto
@@ -30,6 +30,12 @@ service GuardianService {
         };
     }
 
+    rpc GetProviderTypes(GetProviderTypesRequest) returns (GetProviderTypesResponse) {
+        option (google.api.http) = {
+            get: "/v1beta1/providers/types"
+        };
+    }
+
     rpc CreateProvider(CreateProviderRequest) returns (CreateProviderResponse) {
         option (google.api.http) = {
             post: "/v1beta1/providers"
@@ -169,6 +175,12 @@ message GetProviderRequest {
 
 message GetProviderResponse {
     Provider provider = 1;
+}
+
+message GetProviderTypesRequest {}
+
+message GetProviderTypesResponse {
+    repeated ProviderType provider_types = 1;
 }
 
 message CreateProviderRequest {
@@ -415,6 +427,11 @@ message Provider {
 
     google.protobuf.Timestamp created_at = 5;
     google.protobuf.Timestamp updated_at = 6;
+}
+
+message ProviderType {
+    string name = 1;
+    repeated string resource_type = 2;
 }
 
 message Condition {


### PR DESCRIPTION
* add get provider types api for feature request - https://github.com/odpf/guardian/issues/158


**API Request**:
```GET /v1beta1/providers/types```

**API Response(sample)**:
```json
{
  "providers_types": [
    {
      "name": "bigquery",
      "resource_types": [
        "table",
        "dataset"
      ]
    },
    {
      "name": "metabase",
      "resource_types": [
        "group",
        "collection",
        "database"
      ]
    }
  ]
}



```

The resource_types field values such as `table`, `dataset` etc will be singular. 