### PR TITLE
feat(optimus): change GetJobSpecificationsResponse to also include project and namespace name

### DIFF
--- a/odpf/optimus/core/v1beta1/job_spec.proto
+++ b/odpf/optimus/core/v1beta1/job_spec.proto
@@ -338,7 +338,7 @@ message GetJobSpecificationsRequest {
 }
 
 message GetJobSpecificationsResponse {
-  repeated JobSpecification jobs = 1; [deprecated=true];
+  repeated JobSpecification jobs = 1 [deprecated=true];
   repeated JobSpecificationResponse job_specification_responses = 2; 
 }
 

--- a/odpf/optimus/core/v1beta1/job_spec.proto
+++ b/odpf/optimus/core/v1beta1/job_spec.proto
@@ -338,5 +338,11 @@ message GetJobSpecificationsRequest {
 }
 
 message GetJobSpecificationsResponse {
-  repeated JobSpecification jobs = 1; 
+  repeated JobSpecificationResponse jobs = 1; 
+}
+
+message JobSpecificationResponse {
+  string project_name = 1;
+  string namespace_name = 2;
+  JobSpecification job = 3;
 }

--- a/odpf/optimus/core/v1beta1/job_spec.proto
+++ b/odpf/optimus/core/v1beta1/job_spec.proto
@@ -338,7 +338,8 @@ message GetJobSpecificationsRequest {
 }
 
 message GetJobSpecificationsResponse {
-  repeated JobSpecificationResponse jobs = 1; 
+  repeated JobSpecification jobs = 1; [deprecated=true];
+  repeated JobSpecificationResponse job_specification_responses = 2; 
 }
 
 message JobSpecificationResponse {


### PR DESCRIPTION
GetJobSpecificationsResponse should also include project and namespace name. This model is being used by the ongoing development epic of Optimus, thus not deprecating the replaced field.