### PR TITLE
feat: add API for bulk revoke access

### DIFF
--- a/odpf/guardian/v1beta1/guardian.proto
+++ b/odpf/guardian/v1beta1/guardian.proto
@@ -420,7 +420,7 @@ message UpdateApprovalResponse {
 }
 
 message RevokeAppealsRequest {
-    repeated string account_id = 1;
+    repeated string account_ids = 1;
     repeated string provider_types = 2;
     repeated string provider_urns = 3;
     repeated string resource_types = 4;

--- a/odpf/guardian/v1beta1/guardian.proto
+++ b/odpf/guardian/v1beta1/guardian.proto
@@ -173,6 +173,13 @@ service GuardianService {
             body: "action"
         };
     }
+
+    rpc RevokeAppeals(RevokeAppealsRequest) returns (RevokeAppealsResponse) {
+        option (google.api.http) = {
+          post: "/v1beta1/appeals/revoke"
+          body: "*"
+        };
+    }
 }
 
 message ListProvidersRequest {}
@@ -355,6 +362,10 @@ message RevokeAppealResponse {
     Appeal appeal = 1;
 }
 
+message RevokeAppealsResponse {
+  repeated Appeal appeals = 1;
+}
+
 message CreateAppealRequest {
     string account_id = 1;
 
@@ -406,6 +417,16 @@ message UpdateApprovalRequest {
 
 message UpdateApprovalResponse {
     Appeal appeal = 1;
+}
+
+message RevokeAppealsRequest {
+    repeated string account_id = 1;
+    repeated string provider_types = 2;
+    repeated string provider_urns = 3;
+    repeated string resource_types = 4;
+    repeated string resource_urns = 5;
+    repeated string created_by = 6;
+    string reason = 7;
 }
 
 message Role {

--- a/odpf/guardian/v1beta1/guardian.proto
+++ b/odpf/guardian/v1beta1/guardian.proto
@@ -425,8 +425,7 @@ message RevokeAppealsRequest {
     repeated string provider_urns = 3;
     repeated string resource_types = 4;
     repeated string resource_urns = 5;
-    repeated string created_by = 6;
-    string reason = 7;
+    string reason = 6;
 }
 
 message Role {
@@ -578,6 +577,7 @@ message Appeal {
     string account_type = 18;
     string created_by = 19;
     google.protobuf.Value creator = 20;
+    repeated string permissions = 21;
 }
 
 // Approval is an approval item that generated in an appeal based on the selected policy


### PR DESCRIPTION
Add an API to support Bulk access revocation in the [guardian](https://github.com/odpf/guardian/issues/202).

Sample API:

> curl --location --request POST 'localhost:3000/api/v1beta1/appeals/revoke' 
--header 'X-Auth-Email: vikash.singh@gojek.com' 
--header 'Content-Type: application/json' 
--data-raw '{
    "account_id":["vikash.singh@gojek.com", "sushmith.bhatta@gojek.com"],
    "reason": "Bulk revoke"
}'