### PR TITLE
feat: support create/update time in asset metadata

### DIFF
--- a/odpf/assets/v1beta2/asset.proto
+++ b/odpf/assets/v1beta2/asset.proto
@@ -54,9 +54,11 @@ message Asset {
   // Event schemas is defined in the common event schema.
   odpf.assets.v1beta2.Event event = 100;
 
-  // The timestamp when the object was created.
+  // The timestamp when the asset was created.
+  // This information is expected to be maintained by the system.
   google.protobuf.Timestamp create_time = 101;
 
-  // The timestamp when the object was last modified.
+  // The timestamp when the asset was last modified.
+  // This information is expected to be maintained by the system.
   google.protobuf.Timestamp update_time = 102;
 }

--- a/odpf/assets/v1beta2/bucket.proto
+++ b/odpf/assets/v1beta2/bucket.proto
@@ -28,6 +28,12 @@ message Bucket {
 
   // List of attributes the model has.
   google.protobuf.Struct attributes = 10;
+
+  // The timestamp of the bucket's creation.
+  google.protobuf.Timestamp create_time = 101;
+
+  // The timestamp when the bucket was last modified.
+  google.protobuf.Timestamp update_time = 102;
 }
 
 message Blob {

--- a/odpf/assets/v1beta2/dashboard.proto
+++ b/odpf/assets/v1beta2/dashboard.proto
@@ -18,6 +18,12 @@ message Dashboard {
 
   // List of attributes the model has.
   google.protobuf.Struct attributes = 8;
+
+  // The timestamp of the dashboard's creation.
+  google.protobuf.Timestamp create_time = 101;
+
+  // The timestamp when the dashboard was last modified.
+  google.protobuf.Timestamp update_time = 102;
 }
 
 message Chart {

--- a/odpf/assets/v1beta2/job.proto
+++ b/odpf/assets/v1beta2/job.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package odpf.assets.v1beta2;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/odpf/proton/assets/v1beta2;assetsv1beta2";
 option java_outer_classname = "JobProto";
@@ -12,4 +13,10 @@ option java_package = "io.odpf.assets";
 message Job {
   // List of attributes the model has.
   google.protobuf.Struct attributes = 10;
+
+  // The timestamp of the job's creation.
+  google.protobuf.Timestamp create_time = 101;
+
+  // The timestamp when the job was last modified.
+  google.protobuf.Timestamp update_time = 102;
 }

--- a/odpf/assets/v1beta2/table.proto
+++ b/odpf/assets/v1beta2/table.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package odpf.assets.v1beta2;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/odpf/proton/assets/v1beta2;assetsv1beta2";
 option java_outer_classname = "TableProto";
@@ -27,6 +28,12 @@ message Table {
 
   // List of attributes the model has.
   google.protobuf.Struct attributes = 10;
+
+  // The timestamp of the table's creation.
+  google.protobuf.Timestamp create_time = 101;
+
+  // The timestamp when the table was last modified.
+  google.protobuf.Timestamp update_time = 102;
 }
 
 // TableProfile is the metrics about the table.

--- a/odpf/assets/v1beta2/topic.proto
+++ b/odpf/assets/v1beta2/topic.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package odpf.assets.v1beta2;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/odpf/proton/assets/v1beta2;assetsv1beta2";
 option java_outer_classname = "TopicProto";
@@ -15,17 +16,23 @@ message Topic {
   // For an example check out topic profile schema.
   TopicProfile profile = 1;
 
-  // The schama of the topic.
+  // The schema of the topic.
   // For an example check out topic schema.
   TopicSchema schema = 2;
 
   // List of attributes the model has.
   google.protobuf.Struct attributes = 10;
+
+  // The timestamp of the topic's creation.
+  google.protobuf.Timestamp create_time = 101;
+
+  // The timestamp when the topic was last modified.
+  google.protobuf.Timestamp update_time = 102;
 }
 
 // TopicProfile is the profile of the topic.
 message TopicProfile {
-  // The thrroughput of the topic.
+  // The throughput of the topic.
   // Example: `1m/minute`.
   string throughput = 1;
 

--- a/odpf/assets/v1beta2/user.proto
+++ b/odpf/assets/v1beta2/user.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package odpf.assets.v1beta2;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/odpf/proton/assets/v1beta2;assetsv1beta2";
 option java_outer_classname = "UserProto";
@@ -12,7 +13,7 @@ option java_package = "io.odpf.assets";
 // It can be a user of the system, or a user of a device.
 // User is a resource that represents a user.
 message User {
-  // The emai address of the user.
+  // The email address of the user.
   // Example: `job.deo@gmail.com`
   string email = 3;
 
@@ -36,7 +37,7 @@ message User {
   // Example: `John M. Doe`
   string display_name = 8;
 
-  // The job title of the user,
+  // The job title of the user.
   // Example: `data engineer`
   string title = 9;
 
@@ -58,6 +59,12 @@ message User {
 
   // List of attributes the model has.
   google.protobuf.Struct attributes = 30;
+
+  // The timestamp of the user's account creation.
+  google.protobuf.Timestamp create_time = 101;
+
+  // The timestamp when the user's account details were last modified.
+  google.protobuf.Timestamp update_time = 102;
 }
 
 // Membership is a relationship between a user and a group.


### PR DESCRIPTION
The create and update time fields in the Asset proto are meant to track when the asset was first created or updated which would correspond to the first and last time the asset was ingested.

Therefore, add create/update time fields inside specific asset metadata protos:
- Bucket
- Dashboard
- Job
- Table
- Topic
- User

This will track, for example, when a table was created in the database and the last time the table structure was updated.

Related to https://github.com/odpf/meteor/issues/409