### PR TITLE
fix: lint issue in stencil

### DIFF
--- a/odpf/stencil/v1beta1/stencil.proto
+++ b/odpf/stencil/v1beta1/stencil.proto
@@ -142,7 +142,7 @@ service StencilService {
 message Namespace {
   string id = 1;
   Schema.Format format = 2;
-  Schema.Compatibility Compatibility = 3;
+  Schema.Compatibility compatibility = 3;
   string description = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;


### PR DESCRIPTION
fixing lint issue
```bash
odpf/stencil/v1beta1/stencil.proto:145:24:Field name "Compatibility" should be lower_snake_case, such as "compatibility".
```