### PR TITLE
feat: add attributes field for v1beta2 asset types

### DIFF
--- a/odpf/assets/v1beta2/application.proto
+++ b/odpf/assets/v1beta2/application.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package odpf.assets.v1beta2;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/odpf/proton/assets/v1beta2;assetsv1beta2";
@@ -14,6 +15,9 @@ message Application {
 
   // Optional: The version of the service.
   string version = 2;
+
+  // List of attributes the model has.
+  google.protobuf.Struct attributes = 3;
 
   // The timestamp of the service's creation.
   google.protobuf.Timestamp create_time = 101;

--- a/odpf/assets/v1beta2/feature_table.proto
+++ b/odpf/assets/v1beta2/feature_table.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package odpf.assets.v1beta2;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/odpf/proton/assets/v1beta2;assetsv1beta2";
@@ -61,6 +62,9 @@ message FeatureTable {
 
   // Features that are part of the table, akin to columns in a table.
   repeated Feature features = 3;
+
+  // List of attributes the model has.
+  google.protobuf.Struct attributes = 4;
 
   // The timestamp when the feature table was created.
   google.protobuf.Timestamp create_time = 101;


### PR DESCRIPTION
The attributes field was missing in Application and FeatureTable protos.