### PR TITLE
feat(compass): add new field in searchAssetsRequest

### DIFF
--- a/odpf/compass/v1beta1/service.proto
+++ b/odpf/compass/v1beta1/service.proto
@@ -795,6 +795,11 @@ message SearchAssetsRequest {
   map<string, string> query = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "query result based on a (nested) field of the asset. the nested field is written with period separated field name. eg, \"query[data.owner]\""
   }];
+
+  repeated string include_fields = 6 [(validate.rules).repeated = {
+    unique: true,
+    ignore_empty: true
+  }];
 }
 
 message SearchAssetsResponse {


### PR DESCRIPTION
* add `include_fields` param in searchAssetsRequest to give user ability to fetch additional fields which are available in the search hits in elasticsearch

Related to: https://github.com/odpf/compass/issues/196