### PR TITLE
refactor: removed APIs that are replaced by relation APIs

### DIFF
--- a/odpf/shield/v1beta1/shield.proto
+++ b/odpf/shield/v1beta1/shield.proto
@@ -148,68 +148,6 @@ service ShieldService {
     };
   }
 
-  rpc ListGroupUsers(ListGroupUsersRequest) returns (ListGroupUsersResponse) {
-    option (google.api.http) = {
-      get: "/v1beta1/groups/{id}/users",
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Group";
-      summary: "Get all Users in a Group";
-    };
-  }
-
-  rpc AddGroupUser(AddGroupUserRequest) returns (AddGroupUserResponse) {
-    option (google.api.http) = {
-      post: "/v1beta1/groups/{id}/users",
-      body: "body";
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Group";
-      summary: "Add User to Group";
-    };
-  }
-
-  rpc RemoveGroupUser(RemoveGroupUserRequest) returns (RemoveGroupUserResponse) {
-    option (google.api.http) = {
-      delete: "/v1beta1/groups/{id}/users/{user_id}",
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Group";
-      summary: "Remove User from Group";
-    };
-  }
-
-  rpc ListGroupAdmins(ListGroupAdminsRequest) returns (ListGroupAdminsResponse) {
-    option (google.api.http) = {
-      get: "/v1beta1/groups/{id}/admins",
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Group";
-      summary: "Get all Admins of a Group";
-    };
-  }
-
-  rpc AddGroupAdmin(AddGroupAdminRequest) returns (AddGroupAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1beta1/groups/{id}/admins",
-      body: "body";
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Group";
-      summary: "Add Admin to Group";
-    };
-  }
-
-  rpc RemoveGroupAdmin(RemoveGroupAdminRequest) returns (RemoveGroupAdminResponse) {
-    option (google.api.http) = {
-      delete: "/v1beta1/groups/{id}/admins/{user_id}",
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Group";
-      summary: "Remove Admin from Group";
-    };
-  }
-
   rpc ListGroupRelations(ListGroupRelationsRequest) returns (ListGroupRelationsResponse) {
     option (google.api.http) = {
       get: "/v1beta1/groups/{id}/relations"
@@ -780,66 +718,6 @@ message ListGroupsRequest {
 
 message ListGroupsResponse {
   repeated Group groups = 1;
-}
-
-message ListGroupUsersRequest {
-  string id = 1;
-}
-
-message ListGroupUsersResponse {
-  repeated User users = 1;
-}
-
-message AddGroupUserRequestBody {
-  repeated string user_ids = 1;
-}
-
-message AddGroupUserRequest {
-  string id = 1;
-  AddGroupUserRequestBody body = 2;
-}
-
-message AddGroupUserResponse {
-  repeated User users = 1;
-}
-
-message RemoveGroupUserRequest {
-  string id = 1;
-  string user_id = 2;
-}
-
-message RemoveGroupUserResponse {
-  string message = 1;
-}
-
-message ListGroupAdminsRequest {
-  string id = 1;
-}
-
-message ListGroupAdminsResponse {
-  repeated User users = 1;
-}
-
-message AddGroupAdminRequestBody {
-  repeated string user_ids = 1;
-}
-
-message AddGroupAdminRequest {
-  string id = 1;
-  AddGroupAdminRequestBody body = 2;
-}
-
-message AddGroupAdminResponse {
-  repeated User users = 1;
-}
-
-message RemoveGroupAdminRequest {
-  string id = 1;
-  string user_id = 2;
-}
-
-message RemoveGroupAdminResponse {
-  string message = 1;
 }
 
 message Role {

--- a/odpf/shield/v1beta1/shield.proto
+++ b/odpf/shield/v1beta1/shield.proto
@@ -308,27 +308,6 @@ service ShieldService {
     };
   }
 
-  rpc AddProjectAdmin(AddProjectAdminRequest) returns (AddProjectAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1beta1/projects/{id}/admins",
-      body: "body";
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Project";
-      summary: "Add Admin to Project";
-    };
-  }
-
-  rpc RemoveProjectAdmin(RemoveProjectAdminRequest) returns (RemoveProjectAdminResponse) {
-    option (google.api.http) = {
-      delete: "/v1beta1/projects/{id}/admins/{user_id}",
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Project";
-      summary: "Remove Admin from Project";
-    };
-  }
-
   // Actions
   rpc ListActions(ListActionsRequest) returns (ListActionsResponse) {
     option (google.api.http) = {
@@ -858,28 +837,6 @@ message ListProjectAdminsRequest {
 
 message ListProjectAdminsResponse {
   repeated User users = 1;
-}
-
-message AddProjectAdminRequestBody {
-  repeated string user_ids = 1;
-}
-
-message AddProjectAdminRequest {
-  string id = 1;
-  AddProjectAdminRequestBody body = 2;
-}
-
-message AddProjectAdminResponse {
-  repeated User users = 1;
-}
-
-message RemoveProjectAdminRequest {
-  string id = 1;
-  string user_id = 2;
-}
-
-message RemoveProjectAdminResponse {
-  string message = 1;
 }
 
 message Action {

--- a/odpf/shield/v1beta1/shield.proto
+++ b/odpf/shield/v1beta1/shield.proto
@@ -254,26 +254,6 @@ service ShieldService {
     };
   }
 
-  rpc AddOrganizationAdmin(AddOrganizationAdminRequest) returns (AddOrganizationAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1beta1/organizations/{id}/admins",
-      body: "body";
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Organization";
-      summary: "Add Admin to Organization";
-    };
-  }
-
-  rpc RemoveOrganizationAdmin(RemoveOrganizationAdminRequest) returns (RemoveOrganizationAdminResponse) {
-    option (google.api.http) = {
-      delete: "/v1beta1/organizations/{id}/admins/{user_id}",
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Organization";
-      summary: "Remove Admin from Organization";
-    };
-  }
 
   // Projects
   rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
@@ -822,28 +802,6 @@ message ListOrganizationAdminsRequest {
 
 message ListOrganizationAdminsResponse {
   repeated User users = 1;
-}
-
-message AddOrganizationAdminRequestBody {
-  repeated string user_ids = 1;
-}
-
-message AddOrganizationAdminRequest {
-  string id = 1;
-  AddOrganizationAdminRequestBody body = 2;
-}
-
-message AddOrganizationAdminResponse {
-  repeated User users = 1;
-}
-
-message RemoveOrganizationAdminRequest {
-  string id = 1;
-  string user_id = 2;
-}
-
-message RemoveOrganizationAdminResponse {
-  string message = 1;
 }
 
 message ProjectRequestBody {


### PR DESCRIPTION
The following API routes shall go away, as shield now have relation APIs.

RESOURCE
```
AddTeamToResource
AddOwnerToResource
```
GROUP
```
AddUsers 
RemoveUser 
AddAdmins 
RemoveAdmin 
ListGroupUsers 
ListGroupAdmins 
```
ORGANIZATION
```
AddAdmins
RemoveAdmin
```
PROJECT
```
AddAdmins
RemoveAdmin
```