### PR TITLE
feat(compass): support pagination in SearchAssets

### DIFF
--- a/odpf/compass/v1beta1/service.proto
+++ b/odpf/compass/v1beta1/service.proto
@@ -801,13 +801,13 @@ message SearchAssetsRequest {
     ignore_empty: true
   }];
 
-  uint32 from = 7 [
+  uint32 offset = 7 [
     (validate.rules).uint32 = {
       gte: 0,
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "from parameter defines the offset from the first result you want to fetch"
+      description: "offset parameter defines the offset from the first result you want to fetch"
     }
   ];
 }

--- a/odpf/compass/v1beta1/service.proto
+++ b/odpf/compass/v1beta1/service.proto
@@ -800,6 +800,16 @@ message SearchAssetsRequest {
     unique: true,
     ignore_empty: true
   }];
+
+  uint32 from = 7 [
+    (validate.rules).uint32 = {
+      gte: 0,
+      ignore_empty: true
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "from parameter defines the offset from the first result you want to fetch"
+    }
+  ];
 }
 
 message SearchAssetsResponse {


### PR DESCRIPTION
* Add pagination support in SearchAssets API. `from` would be the offset and `size` would be the page size. The changes are backward compatible