### PR TITLE
chore: remove deprecated protoc-gen-connect-es

### DIFF
--- a/js/buf.gen.yaml
+++ b/js/buf.gen.yaml
@@ -7,10 +7,6 @@ plugins:
     out: js/dist
   - name: ts
     out: js/dist
-  - name: connect-es
-    opt:
-      - target=ts
-    out: js/dist
   - name: connect-query
     opt:
       - target=ts

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -10,17 +10,10 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.6.2",
-        "@connectrpc/protoc-gen-connect-es": "^1.6.1",
         "@connectrpc/protoc-gen-connect-query": "^2.1.1",
         "@protobuf-ts/plugin": "^2.11.1",
         "chalk": "^5.4.1"
       }
-    },
-    "node_modules/@bufbuild/protobuf": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
-      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
-      "dev": true
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.6.2",
@@ -78,45 +71,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@bufbuild/protoplugin": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-1.10.1.tgz",
-      "integrity": "sha512-LaSbfwabAFIvbVnbn8jWwElRoffCIxhVraO8arliVwWupWezHLXgqPHEYLXZY/SsAR+/YsFBQJa8tAGtNPJyaQ==",
-      "dev": true,
-      "dependencies": {
-        "@bufbuild/protobuf": "1.10.1",
-        "@typescript/vfs": "^1.4.0",
-        "typescript": "4.5.2"
-      }
-    },
-    "node_modules/@connectrpc/protoc-gen-connect-es": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/protoc-gen-connect-es/-/protoc-gen-connect-es-1.6.1.tgz",
-      "integrity": "sha512-0fHcaADd+GKM0I/koIQpmKg7b+QL18bXlggTUYEAlMFzsd4zN/ApG3235hdUcRyhrAOAItTXxh8ZAV/nNd43Gg==",
-      "dev": true,
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.10.0",
-        "@bufbuild/protoplugin": "^1.10.0"
-      },
-      "bin": {
-        "protoc-gen-connect-es": "bin/protoc-gen-connect-es"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@bufbuild/protoc-gen-es": "^1.10.0",
-        "@connectrpc/connect": "1.6.1"
-      },
-      "peerDependenciesMeta": {
-        "@bufbuild/protoc-gen-es": {
-          "optional": true
-        },
-        "@connectrpc/connect": {
-          "optional": true
-        }
       }
     },
     "node_modules/@connectrpc/protoc-gen-connect-query": {
@@ -314,6 +268,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
       "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/js/package.json
+++ b/js/package.json
@@ -10,7 +10,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "^2.6.2",
-    "@connectrpc/protoc-gen-connect-es": "^1.6.1",
     "@connectrpc/protoc-gen-connect-query": "^2.1.1",
     "@protobuf-ts/plugin": "^2.11.1",
     "chalk": "^5.4.1"


### PR DESCRIPTION
This PR removes protoc-gen-connect-es as it is not needed in v2
https://github.com/connectrpc/connect-es/blob/main/MIGRATING.md#dependency-updates-in-packagejson