### PR TITLE
fix(frontier): revert removal of some deprecated fields

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -542,8 +542,9 @@ message CreateBillingUsageResponse {}
 
 message ListBillingTransactionsRequest {
   string org_id = 1 [(buf.validate.field).string.min_len = 3];
-  reserved 2, 3;
+  reserved 2;
 
+  google.protobuf.Timestamp since = 3 [deprecated = true];
   google.protobuf.Timestamp start_range = 4;
   google.protobuf.Timestamp end_range = 5;
 
@@ -609,10 +610,18 @@ message UpdateSubscriptionResponse {
 }
 
 message ChangeSubscriptionRequest {
-  reserved 1, 2, 4, 5;
+  reserved 1, 2;
 
   // ID of the subscription to update
   string id = 3 [(buf.validate.field).string.min_len = 1];
+
+  // plan to change to
+  // deprecated in favor of plan_change
+  string plan = 4 [deprecated = true];
+
+  // should the change be immediate or at the end of the current billing period
+  // deprecated in favor of plan_change
+  bool immediate = 5 [deprecated = true];
 
   message PlanChange {
     // plan to change to

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -519,7 +519,10 @@ message GetBillingBalanceResponse {
 }
 
 message HasTrialedRequest {
-  reserved 1, 2;
+  // ID of the billing account to check
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  reserved 2;
 
   // ID of the plan to check
   string plan_id = 3 [(buf.validate.field).string.min_len = 1];


### PR DESCRIPTION
## Summary
- Revert removal of deprecated fields that are still in use:
  - `ChangeSubscriptionRequest.plan` (field 4) and `ChangeSubscriptionRequest.immediate` (field 5)
  - `ListBillingTransactionsRequest.since` (field 3)

## Test plan
- [ ] Verify proto compiles successfully
- [ ] Verify dependent services still work with these fields