### PR TITLE
feat(frontier): add AddOrganizationMembers RPC

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -1053,7 +1053,10 @@ message ListAuditRecordsResponse {
 }
 
 message SearchOrganizationPATsRequest {
-  string org_id = 1 [(buf.validate.field).string.uuid = true];
+  string org_id = 1 [
+    (buf.validate.field).string.uuid = true,
+    (google.api.field_behavior) = REQUIRED
+  ];
   RQLRequest query = 2;
 }
 

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -27,6 +27,8 @@ service AdminService {
 
   rpc AdminCreateOrganization(AdminCreateOrganizationRequest) returns (AdminCreateOrganizationResponse) {}
 
+  rpc AddOrganizationMembers(AddOrganizationMembersRequest) returns (AddOrganizationMembersResponse) {}
+
   rpc SearchOrganizations(SearchOrganizationsRequest) returns (SearchOrganizationsResponse) {}
 
   rpc SearchOrganizationUsers(SearchOrganizationUsersRequest) returns (SearchOrganizationUsersResponse) {}
@@ -1077,4 +1079,24 @@ message SearchOrganizationPATsResponse {
 
   repeated OrganizationPAT organization_pats = 1;
   RQLQueryPaginationResponse pagination = 2;
+}
+
+message AddOrganizationMembersRequest {
+  string org_id = 1 [(buf.validate.field).string.uuid = true];
+  repeated OrgMemberEntry members = 2;
+}
+
+message OrgMemberEntry {
+  string user_id = 1 [(buf.validate.field).string.uuid = true];
+  string role_id = 2 [(buf.validate.field).string.uuid = true];
+}
+
+message AddOrganizationMembersResponse {
+  repeated OrgMemberResult results = 1;
+}
+
+message OrgMemberResult {
+  string user_id = 1;
+  bool success = 2;
+  string error = 3;
 }

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -1082,7 +1082,10 @@ message SearchOrganizationPATsResponse {
 }
 
 message AddOrganizationMembersRequest {
-  string org_id = 1 [(buf.validate.field).string.uuid = true];
+  string org_id = 1 [
+    (buf.validate.field).string.uuid = true,
+    (google.api.field_behavior) = REQUIRED
+  ];
   repeated OrgMemberEntry members = 2 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -1083,7 +1083,7 @@ message SearchOrganizationPATsResponse {
 
 message AddOrganizationMembersRequest {
   string org_id = 1 [(buf.validate.field).string.uuid = true];
-  repeated OrgMemberEntry members = 2;
+  repeated OrgMemberEntry members = 2 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message OrgMemberEntry {
@@ -1097,6 +1097,7 @@ message AddOrganizationMembersResponse {
 
 message OrgMemberResult {
   string user_id = 1;
-  bool success = 2;
-  string error = 3;
+  string role_id = 2;
+  bool success = 3;
+  string error = 4;
 }

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -1053,10 +1053,7 @@ message ListAuditRecordsResponse {
 }
 
 message SearchOrganizationPATsRequest {
-  string org_id = 1 [
-    (buf.validate.field).string.uuid = true,
-    (google.api.field_behavior) = REQUIRED
-  ];
+  string org_id = 1 [(buf.validate.field).string.uuid = true];
   RQLRequest query = 2;
 }
 
@@ -1082,10 +1079,7 @@ message SearchOrganizationPATsResponse {
 }
 
 message AddOrganizationMembersRequest {
-  string org_id = 1 [
-    (buf.validate.field).string.uuid = true,
-    (google.api.field_behavior) = REQUIRED
-  ];
+  string org_id = 1 [(buf.validate.field).string.uuid = true];
   repeated OrgMemberEntry members = 2 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -133,8 +133,6 @@ service FrontierService {
 
   rpc SetOrganizationMemberRole(SetOrganizationMemberRoleRequest) returns (SetOrganizationMemberRoleResponse) {}
 
-  rpc AddOrganizationMembers(AddOrganizationMembersRequest) returns (AddOrganizationMembersResponse) {}
-
   rpc GetOrganizationKyc(GetOrganizationKycRequest) returns (GetOrganizationKycResponse) {}
 
   // Deprecated: use ListServiceUsers instead
@@ -1598,26 +1596,6 @@ message SetOrganizationMemberRoleRequest {
 }
 
 message SetOrganizationMemberRoleResponse {}
-
-message AddOrganizationMembersRequest {
-  string org_id = 1 [(buf.validate.field).string.uuid = true];
-  repeated OrgMemberEntry members = 2;
-}
-
-message OrgMemberEntry {
-  string user_id = 1 [(buf.validate.field).string.uuid = true];
-  string role_id = 2 [(buf.validate.field).string.uuid = true];
-}
-
-message AddOrganizationMembersResponse {
-  repeated OrgMemberResult results = 1;
-}
-
-message OrgMemberResult {
-  string user_id = 1;
-  bool success = 2;
-  string error = 3;
-}
 
 message ListOrganizationServiceUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -133,6 +133,8 @@ service FrontierService {
 
   rpc SetOrganizationMemberRole(SetOrganizationMemberRoleRequest) returns (SetOrganizationMemberRoleResponse) {}
 
+  rpc AddOrganizationMembers(AddOrganizationMembersRequest) returns (AddOrganizationMembersResponse) {}
+
   rpc GetOrganizationKyc(GetOrganizationKycRequest) returns (GetOrganizationKycResponse) {}
 
   // Deprecated: use ListServiceUsers instead
@@ -1596,6 +1598,26 @@ message SetOrganizationMemberRoleRequest {
 }
 
 message SetOrganizationMemberRoleResponse {}
+
+message AddOrganizationMembersRequest {
+  string org_id = 1 [(buf.validate.field).string.uuid = true];
+  repeated OrgMemberEntry members = 2;
+}
+
+message OrgMemberEntry {
+  string user_id = 1 [(buf.validate.field).string.uuid = true];
+  string role_id = 2 [(buf.validate.field).string.uuid = true];
+}
+
+message AddOrganizationMembersResponse {
+  repeated OrgMemberResult results = 1;
+}
+
+message OrgMemberResult {
+  string user_id = 1;
+  bool success = 2;
+  string error = 3;
+}
 
 message ListOrganizationServiceUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];


### PR DESCRIPTION
## Summary
- Add `AddOrganizationMembers` RPC that accepts a list of `{user_id, role_id}` pairs with UUID validation
- Returns per-member `{user_id, success, error}` results for partial failure handling
- Intended to eventually replace `AddOrganizationUsers` which lacks a role parameter and hardcodes the default viewer role

## Example

**Request**
```json
{
  "org_id": "a9a62b93-ae6f-4aba-9c32-73281c49da73",
  "members": [
    {
      "user_id": "998d7ebe-cd2c-4f0c-a560-7dd2a7d1a62c",
      "role_id": "e57e1ba4-21fd-43a4-8aca-aa560afb32cf"
    },
    {
      "user_id": "6a51c542-7ca9-4b23-8709-74145013d919",
      "role_id": "afe94f10-1508-4379-88b1-2c328cb2b769"
    }
  ]
}
```

**Response**
```json
{
  "results": [
    {
      "user_id": "998d7ebe-cd2c-4f0c-a560-7dd2a7d1a62c",
      "success": true,
      "error": ""
    },
    {
      "user_id": "6a51c542-7ca9-4b23-8709-74145013d919",
      "success": false,
      "error": "principal is already a member of this resource"
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)