### PR TITLE
fix: remove unused google/protobuf/descriptor.proto imports

### DIFF
--- a/raystack/siren/v1beta1/siren.proto
+++ b/raystack/siren/v1beta1/siren.proto
@@ -4,7 +4,6 @@ package raystack.siren.v1beta1;
 
 import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
-import "google/protobuf/descriptor.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";

--- a/raystack/stencil/v1beta1/stencil.proto
+++ b/raystack/stencil/v1beta1/stencil.proto
@@ -4,7 +4,6 @@ package raystack.stencil.v1beta1;
 
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
-import "google/protobuf/descriptor.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 


### PR DESCRIPTION
## Summary
Neither `siren.proto` nor `stencil.proto` uses proto extensions that require `google/protobuf/descriptor.proto`. Stricter lint in buf `1.68.1` now flags these as errors, blocking CI on PRs.

## Why
- `buf 1.68.1` (latest) added/strengthened the `IMPORT_USED` lint rule
- The workflow uses `bufbuild/buf-action@v1` without pinning a version → picks up latest
- Previously merged PRs passed on `buf 1.67.0` because the rule wasn't enforced there
- Affects all new PRs until this is fixed

## Changes
- `raystack/siren/v1beta1/siren.proto` — remove unused `descriptor.proto` import
- `raystack/stencil/v1beta1/stencil.proto` — remove unused `descriptor.proto` import

Verified no extension usages (`FieldOptions`, `MessageOptions`, `extend`, etc.) in either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)