### PR TITLE
feat(frontier): add RemoveOrganizationMember RPC

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -133,6 +133,8 @@ service FrontierService {
 
   rpc SetOrganizationMemberRole(SetOrganizationMemberRoleRequest) returns (SetOrganizationMemberRoleResponse) {}
 
+  rpc RemoveOrganizationMember(RemoveOrganizationMemberRequest) returns (RemoveOrganizationMemberResponse) {}
+
   rpc GetOrganizationKyc(GetOrganizationKycRequest) returns (GetOrganizationKycResponse) {}
 
   // Deprecated: use ListServiceUsers instead
@@ -1618,6 +1620,14 @@ message SetOrganizationMemberRoleRequest {
 }
 
 message SetOrganizationMemberRoleResponse {}
+
+message RemoveOrganizationMemberRequest {
+  string org_id = 1 [(buf.validate.field).string.uuid = true];
+  string principal_id = 2 [(buf.validate.field).string.uuid = true];
+  string principal_type = 3 [(buf.validate.field).string.min_len = 1];
+}
+
+message RemoveOrganizationMemberResponse {}
 
 message ListOrganizationServiceUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -129,8 +129,6 @@ service FrontierService {
 
   rpc AddOrganizationUsers(AddOrganizationUsersRequest) returns (AddOrganizationUsersResponse) {}
 
-  rpc RemoveOrganizationUser(RemoveOrganizationUserRequest) returns (RemoveOrganizationUserResponse) {}
-
   rpc SetOrganizationMemberRole(SetOrganizationMemberRoleRequest) returns (SetOrganizationMemberRoleResponse) {}
 
   rpc RemoveOrganizationMember(RemoveOrganizationMemberRequest) returns (RemoveOrganizationMemberResponse) {}
@@ -1605,13 +1603,6 @@ message AddOrganizationUsersRequest {
 }
 
 message AddOrganizationUsersResponse {}
-
-message RemoveOrganizationUserRequest {
-  string id = 1 [(buf.validate.field).string.min_len = 3];
-  string user_id = 2;
-}
-
-message RemoveOrganizationUserResponse {}
 
 message SetOrganizationMemberRoleRequest {
   string org_id = 1 [(buf.validate.field).string.uuid = true];


### PR DESCRIPTION
## Summary
- Add `RemoveOrganizationMember` RPC to `FrontierService` in `frontier.proto`
- Request takes `org_id`, `principal_id`, and `principal_type` (supports all principal types, not just users)
- Placed alongside existing membership RPCs (`SetOrganizationMemberRole`, `RemoveOrganizationUser`)