### PR TITLE
refactor(frontier): move SearchOrganizationInvoices to FrontierService

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -37,8 +37,6 @@ service AdminService {
 
   rpc SearchOrganizationProjects(SearchOrganizationProjectsRequest) returns (SearchOrganizationProjectsResponse) {}
 
-  rpc SearchOrganizationInvoices(SearchOrganizationInvoicesRequest) returns (SearchOrganizationInvoicesResponse) {}
-
   rpc SearchOrganizationTokens(SearchOrganizationTokensRequest) returns (SearchOrganizationTokensResponse) {}
 
   rpc SearchOrganizationServiceUserCredentials(SearchOrganizationServiceUserCredentialsRequest) returns (SearchOrganizationServiceUserCredentialsResponse) {}
@@ -793,27 +791,6 @@ message SearchProjectUsersResponse {
   }
 
   repeated ProjectUser project_users = 1;
-  RQLQueryPaginationResponse pagination = 2;
-  RQLQueryGroupResponse group = 3;
-}
-
-message SearchOrganizationInvoicesRequest {
-  string id = 1 [(buf.validate.field).string.min_len = 3];
-  RQLRequest query = 2;
-}
-
-message SearchOrganizationInvoicesResponse {
-  message OrganizationInvoice {
-    string id = 1;
-    int64 amount = 2;
-    string currency = 3;
-    string state = 4;
-    string invoice_link = 5;
-    google.protobuf.Timestamp created_at = 6;
-    string org_id = 7;
-  }
-
-  repeated OrganizationInvoice organization_invoices = 1;
   RQLQueryPaginationResponse pagination = 2;
   RQLQueryGroupResponse group = 3;
 }

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -370,7 +370,7 @@ service FrontierService {
 
   // Invoice
   rpc ListInvoices(ListInvoicesRequest) returns (ListInvoicesResponse) {}
-  rpc SearchOrganisationInvoices(SearchOrganisationInvoicesRequest) returns (SearchOrganisationInvoicesResponse) {}
+  rpc SearchOrganizationInvoices(SearchOrganizationInvoicesRequest) returns (SearchOrganizationInvoicesResponse) {}
 
   rpc GetUpcomingInvoice(GetUpcomingInvoiceRequest) returns (GetUpcomingInvoiceResponse) {}
 
@@ -909,14 +909,25 @@ message ListInvoicesResponse {
   repeated Invoice invoices = 1;
 }
 
-message SearchOrganisationInvoicesRequest {
-  string org_id = 1 [(buf.validate.field).string.min_len = 3];
+message SearchOrganizationInvoicesRequest {
+  string id = 1 [(buf.validate.field).string.min_len = 3];
   RQLRequest query = 2;
 }
 
-message SearchOrganisationInvoicesResponse {
-  repeated Invoice invoices = 1;
+message SearchOrganizationInvoicesResponse {
+  message OrganizationInvoice {
+    string id = 1;
+    int64 amount = 2;
+    string currency = 3;
+    string state = 4;
+    string invoice_link = 5;
+    google.protobuf.Timestamp created_at = 6;
+    string org_id = 7;
+  }
+
+  repeated OrganizationInvoice organization_invoices = 1;
   RQLQueryPaginationResponse pagination = 2;
+  RQLQueryGroupResponse group = 3;
 }
 
 message GetUpcomingInvoiceRequest {


### PR DESCRIPTION
[PR-1549](https://github.com/raystack/frontier/pull/1549)

## Summary
- Move \`SearchOrganizationInvoices\` RPC from \`AdminService\` to \`FrontierService\` so admins and non-admin clients both can access the RQL.
- Request/response shape is preserved from the admin version: nested \`OrganizationInvoice\` projection + \`RQLQueryPaginationResponse\` + \`RQLQueryGroupResponse\`.

## Follow-up
A corresponding frontier PR will:
- Bump \`PROTON_COMMIT\` and regenerate Go protos (handler on \`*ConnectHandler\` continues to satisfy the right interface after regen — no code move required beyond server registration).
- Swap the \`authorization.go\` entry for this RPC from \`IsSuperUser\` to \`IsAuthorized(org, UpdatePermission)\` (matches the gate on \`ListInvoices\`).
- Switch the admin dashboard frontend from \`AdminServiceQueries.searchOrganizationInvoices\` to \`FrontierServiceQueries.searchOrganizationInvoices\`.

## Test plan
- [ ] \`buf build\` / \`buf lint\` pass
- [ ] Consumers of the generated code (frontier Go, @raystack/proton JS) regenerate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)