### PR TITLE
feat(compass): remove upstreams/downstreams from UpsertEntityRequest

### DIFF
--- a/raystack/compass/v1beta1/service.proto
+++ b/raystack/compass/v1beta1/service.proto
@@ -128,8 +128,10 @@ message UpsertEntityRequest {
   string description = 4;
   google.protobuf.Struct properties = 5;
   string source = 6;
-  repeated string upstreams = 7;
-  repeated string downstreams = 8;
+  // Fields 7, 8 removed: upstreams/downstreams are now represented as
+  // edges (derived_from / generates) via UpsertEdge.
+  reserved 7, 8;
+  reserved "upstreams", "downstreams";
 }
 
 message UpsertEntityResponse {


### PR DESCRIPTION
Lineage is now represented as edges with types derived_from and generates, sent via UpsertEdge like all other relationships. This removes the special-case handling where lineage was inlined on the entity while all other edges used the edge API.