### PR TITLE
feat(compass): replace User with Principal, remove Stars

### DIFF
--- a/raystack/compass/v1beta1/service.proto
+++ b/raystack/compass/v1beta1/service.proto
@@ -128,8 +128,10 @@ message UpsertEntityRequest {
   string description = 4;
   google.protobuf.Struct properties = 5;
   string source = 6;
-  repeated string upstreams = 7;
-  repeated string downstreams = 8;
+  // Fields 7, 8 removed: upstreams/downstreams are now represented as
+  // edges (derived_from / generates) via UpsertEdge.
+  reserved 7, 8;
+  reserved "upstreams", "downstreams";
 }
 
 message UpsertEntityResponse {

--- a/raystack/compass/v1beta1/service.proto
+++ b/raystack/compass/v1beta1/service.proto
@@ -30,14 +30,6 @@ service CompassService {
   rpc GetEdges(GetEdgesRequest) returns (GetEdgesResponse) {}
   rpc DeleteEdge(DeleteEdgeRequest) returns (DeleteEdgeResponse) {}
 
-  // Domain: Star
-  rpc StarEntity(StarEntityRequest) returns (StarEntityResponse) {}
-  rpc UnstarEntity(UnstarEntityRequest) returns (UnstarEntityResponse) {}
-  rpc GetUserStarredEntities(GetUserStarredEntitiesRequest) returns (GetUserStarredEntitiesResponse) {}
-  rpc GetMyStarredEntities(GetMyStarredEntitiesRequest) returns (GetMyStarredEntitiesResponse) {}
-  rpc GetMyStarredEntity(GetMyStarredEntityRequest) returns (GetMyStarredEntityResponse) {}
-  rpc GetEntityStargazers(GetEntityStargazersRequest) returns (GetEntityStargazersResponse) {}
-
   // Domain: Namespace
   rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse) {}
   rpc GetNamespace(GetNamespaceRequest) returns (GetNamespaceResponse) {}
@@ -49,13 +41,14 @@ service CompassService {
 // Core messages
 // ============================================================
 
-message User {
+message Principal {
   string id = 1;
-  string uuid = 2;
-  string email = 3;
-  string provider = 4;
-  google.protobuf.Timestamp created_at = 5;
-  google.protobuf.Timestamp updated_at = 6;
+  string type = 2;      // "user", "agent", "service"
+  string name = 3;
+  string subject = 4;   // JWT sub claim, unique external identity
+  google.protobuf.Struct metadata = 5;
+  google.protobuf.Timestamp created_at = 6;
+  google.protobuf.Timestamp updated_at = 7;
 }
 
 message Entity {
@@ -234,61 +227,6 @@ message DeleteEdgeRequest {
 }
 
 message DeleteEdgeResponse {}
-
-// ============================================================
-// Star
-// ============================================================
-
-message StarEntityRequest {
-  string entity_id = 1;
-}
-
-message StarEntityResponse {
-  string id = 1;
-}
-
-message UnstarEntityRequest {
-  string entity_id = 1;
-}
-
-message UnstarEntityResponse {}
-
-message GetUserStarredEntitiesRequest {
-  string user_id = 1;
-  uint32 size = 2 [(buf.validate.field).uint32 = {gte: 0}];
-  uint32 offset = 3 [(buf.validate.field).uint32 = {gte: 0}];
-}
-
-message GetUserStarredEntitiesResponse {
-  repeated Entity data = 1;
-}
-
-message GetMyStarredEntitiesRequest {
-  uint32 size = 1 [(buf.validate.field).uint32 = {gte: 0}];
-  uint32 offset = 2 [(buf.validate.field).uint32 = {gte: 0}];
-}
-
-message GetMyStarredEntitiesResponse {
-  repeated Entity data = 1;
-}
-
-message GetMyStarredEntityRequest {
-  string entity_id = 1;
-}
-
-message GetMyStarredEntityResponse {
-  Entity data = 1;
-}
-
-message GetEntityStargazersRequest {
-  string id = 1;
-  uint32 size = 2 [(buf.validate.field).uint32 = {gte: 0}];
-  uint32 offset = 3 [(buf.validate.field).uint32 = {gte: 0}];
-}
-
-message GetEntityStargazersResponse {
-  repeated User data = 1;
-}
 
 // ============================================================
 // Namespace


### PR DESCRIPTION
## Summary

- Replace `User` message with `Principal` (id, type, name, subject, metadata, timestamps) to support humans, AI agents, and services as first-class callers
- Remove all Star/Favorites RPCs and messages — replaced by usage signals in Compass
- Remove upstreams/downstreams from UpsertEntityRequest (edges via UpsertEdge)

## Context

Compass is evolving from a data catalog into an agent-native context engine. The identity model needs to support AI agents and services alongside human users. The Star/Favorites system was a catalog-era feature being replaced by automatic usage signal collection.

## Changes

**New `Principal` message:**
```protobuf
message Principal {
  string id = 1;
  string type = 2;      // "user", "agent", "service"
  string name = 3;
  string subject = 4;   // JWT sub claim
  google.protobuf.Struct metadata = 5;
  google.protobuf.Timestamp created_at = 6;
  google.protobuf.Timestamp updated_at = 7;
}
```

**Removed RPCs:** StarEntity, UnstarEntity, GetUserStarredEntities, GetMyStarredEntities, GetMyStarredEntity, GetEntityStargazers

**Removed messages:** User, all Star request/response types