### PR TITLE
refactor(frontier): remove AddOrganizationUsers RPC

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -127,8 +127,6 @@ service FrontierService {
 
   rpc ListOrganizationUsers(ListOrganizationUsersRequest) returns (ListOrganizationUsersResponse) {}
 
-  rpc AddOrganizationUsers(AddOrganizationUsersRequest) returns (AddOrganizationUsersResponse) {}
-
   rpc SetOrganizationMemberRole(SetOrganizationMemberRoleRequest) returns (SetOrganizationMemberRoleResponse) {}
 
   rpc RemoveOrganizationMember(RemoveOrganizationMemberRequest) returns (RemoveOrganizationMemberResponse) {}
@@ -1597,12 +1595,6 @@ message ListOrganizationUsersResponse {
   repeated RolePair role_pairs = 2;
 }
 
-message AddOrganizationUsersRequest {
-  string id = 1 [(buf.validate.field).string.min_len = 3];
-  repeated string user_ids = 2;
-}
-
-message AddOrganizationUsersResponse {}
 
 message SetOrganizationMemberRoleRequest {
   string org_id = 1 [(buf.validate.field).string.uuid = true];


### PR DESCRIPTION
## Summary
- Removes the `AddOrganizationUsers` RPC, request message, and response message from `FrontierService`
- This RPC has been superseded by `AddOrganizationMembers` on `AdminService`, which supports explicit role assignment per member
- Server-side handler was already removed in raystack/frontier#1548

## Context
`AddOrganizationUsers` added members with a hardcoded viewer role and no way to specify the desired role. The replacement `AddOrganizationMembers` (on `AdminService`) accepts a role per member and is gated behind superadmin auth.

## Test plan
- [x] `buf lint` passes
- [x] `buf breaking` passes (WIRE category allows RPC removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)