### PR TITLE
refactor(frontier): move SearchOrganizationTokens to FrontierService

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -37,8 +37,6 @@ service AdminService {
 
   rpc SearchOrganizationProjects(SearchOrganizationProjectsRequest) returns (SearchOrganizationProjectsResponse) {}
 
-  rpc SearchOrganizationTokens(SearchOrganizationTokensRequest) returns (SearchOrganizationTokensResponse) {}
-
   rpc SearchOrganizationServiceUserCredentials(SearchOrganizationServiceUserCredentialsRequest) returns (SearchOrganizationServiceUserCredentialsResponse) {}
 
   rpc SearchOrganizationServiceUsers(SearchOrganizationServiceUsersRequest) returns (SearchOrganizationServiceUsersResponse) {}
@@ -791,28 +789,6 @@ message SearchProjectUsersResponse {
   }
 
   repeated ProjectUser project_users = 1;
-  RQLQueryPaginationResponse pagination = 2;
-  RQLQueryGroupResponse group = 3;
-}
-
-message SearchOrganizationTokensRequest {
-  string id = 1 [(buf.validate.field).string.min_len = 3];
-  RQLRequest query = 2;
-}
-
-message SearchOrganizationTokensResponse {
-  message OrganizationToken {
-    int64 amount = 1;
-    string type = 2;
-    string description = 3;
-    string user_id = 4;
-    string user_title = 5;
-    string user_avatar = 6;
-    google.protobuf.Timestamp created_at = 7;
-    string org_id = 8;
-  }
-
-  repeated OrganizationToken organization_tokens = 1;
   RQLQueryPaginationResponse pagination = 2;
   RQLQueryGroupResponse group = 3;
 }

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -363,6 +363,7 @@ service FrontierService {
   rpc CreateBillingUsage(CreateBillingUsageRequest) returns (CreateBillingUsageResponse) {}
 
   rpc ListBillingTransactions(ListBillingTransactionsRequest) returns (ListBillingTransactionsResponse) {}
+  rpc SearchOrganizationTokens(SearchOrganizationTokensRequest) returns (SearchOrganizationTokensResponse) {}
 
   rpc TotalDebitedTransactions(TotalDebitedTransactionsRequest) returns (TotalDebitedTransactionsResponse) {}
 
@@ -566,6 +567,28 @@ message TotalDebitedTransactionsRequest {
 message TotalDebitedTransactionsResponse {
   // Total debited amount in the billing account
   BillingAccount.Balance debited = 1;
+}
+
+message SearchOrganizationTokensRequest {
+  string id = 1 [(buf.validate.field).string.min_len = 3];
+  RQLRequest query = 2;
+}
+
+message SearchOrganizationTokensResponse {
+  message OrganizationToken {
+    int64 amount = 1;
+    string type = 2;
+    string description = 3;
+    string user_id = 4;
+    string user_title = 5;
+    string user_avatar = 6;
+    google.protobuf.Timestamp created_at = 7;
+    string org_id = 8;
+  }
+
+  repeated OrganizationToken organization_tokens = 1;
+  RQLQueryPaginationResponse pagination = 2;
+  RQLQueryGroupResponse group = 3;
 }
 
 message GetSubscriptionRequest {


### PR DESCRIPTION
## Summary
- Move \`SearchOrganizationTokens\` RPC from \`AdminService\` → \`FrontierService\` so org admins (not only platform super-users) can list their own org's token transactions
- Request/response shape preserved: nested \`OrganizationToken\` projection + \`RQLQueryPaginationResponse\` + \`RQLQueryGroupResponse\`.

## Follow-up
A corresponding frontier PR will:
- Bump \`PROTON_COMMIT\` and regenerate Go protos.
- Swap the \`authorization.go\` entry from \`IsSuperUser\` to \`IsAuthorized(org, UpdatePermission)\`.
- Update the admin dashboard Tokens page from \`AdminServiceQueries.searchOrganizationTokens\` → \`FrontierServiceQueries.searchOrganizationTokens\`.
- Rewrite the views-new SDK Tokens page from \`listBillingTransactions\` (non-RQL, client mode) to \`searchOrganizationTokens\` with \`useInfiniteQuery\` + server-mode sort/filter.

## Test plan
- [ ] \`buf build\` / \`buf lint\` pass
- [ ] Downstream consumers (frontier Go, @raystack/proton JS) regenerate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)