### PR TITLE
refactor(frontier): remove deprecated fields from list member request messages

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1603,9 +1603,8 @@ message ListOrganizationAdminsResponse {
 
 message ListOrganizationUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];
-  reserved 2;
+  reserved 2, 3;
 
-  bool with_roles = 3;
   repeated string role_filters = 4;
 }
 
@@ -1867,9 +1866,7 @@ message ListProjectAdminsResponse {
 
 message ListProjectUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];
-  reserved 2;
-
-  bool with_roles = 3;
+  reserved 2, 3;
 }
 
 message ListProjectUsersResponse {
@@ -1884,7 +1881,7 @@ message ListProjectUsersResponse {
 
 message ListProjectServiceUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];
-  bool with_roles = 3;
+  reserved 3;
 }
 
 message ListProjectServiceUsersResponse {
@@ -1899,7 +1896,7 @@ message ListProjectServiceUsersResponse {
 
 message ListProjectGroupsRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];
-  bool with_roles = 2;
+  reserved 2;
 }
 
 message ListProjectGroupsResponse {
@@ -2129,8 +2126,7 @@ message UpdateGroupRequest {
 message ListGroupUsersRequest {
   string id = 1;
   string org_id = 2;
-
-  bool with_roles = 3;
+  reserved 3;
 }
 
 message ListGroupUsersResponse {

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1605,7 +1605,7 @@ message ListOrganizationUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];
   reserved 2, 3;
 
-  repeated string role_filters = 4;
+  repeated string role_ids = 4 [(buf.validate.field).repeated.items.string.uuid = true];
 }
 
 message ListOrganizationUsersResponse {

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1603,7 +1603,7 @@ message ListOrganizationAdminsResponse {
 
 message ListOrganizationUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];
-  string permission_filter = 2 [deprecated = true];
+  reserved 2;
 
   bool with_roles = 3;
   repeated string role_filters = 4;

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1867,7 +1867,7 @@ message ListProjectAdminsResponse {
 
 message ListProjectUsersRequest {
   string id = 1 [(buf.validate.field).string.min_len = 3];
-  string permission_filter = 2;
+  reserved 2;
 
   bool with_roles = 3;
 }


### PR DESCRIPTION
## Summary
- Remove `permission_filter` field from `ListOrganizationUsersRequest` and `ListProjectUsersRequest`, reserve field ids
- Remove `with_roles` field from `ListOrganizationUsersRequest`, `ListProjectUsersRequest`, `ListProjectServiceUsersRequest`, `ListProjectGroupsRequest`, and `ListGroupUsersRequest`, reserve field ids

## Test plan
- [ ] Verify buf lint passes
- [ ] Verify downstream services compile against updated proto