### PR TITLE
feat(frontier): add source field to SearchOrganizationTokensResponse

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -584,6 +584,7 @@ message SearchOrganizationTokensResponse {
     string user_avatar = 6;
     google.protobuf.Timestamp created_at = 7;
     string org_id = 8;
+    string source = 9;
   }
 
   repeated OrganizationToken organization_tokens = 1;


### PR DESCRIPTION
## Summary
Adds \`string source = 9\` to \`SearchOrganizationTokensResponse.OrganizationToken\`. The source field is already stored on \`billing_transactions.source\` server-side and carries values like \`system.starter\`, \`system.buy\`, \`system.awarded\`, \`system.revert\`, \`system.overdraft\`.

Exposing it on the RPC response lets the SDK restore the old Tokens page behavior — friendly Event column labels (e.g. \`system.buy\` → "Recharge") and a multiselect filter by event type.

## Follow-up
Frontier backend change will populate this field from the repository. SDK views-new Tokens page will re-introduce \`TxnEventSourceMap\` with the new \`system.overdraft\` value included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)