### PR TITLE
feat(frontier): add SetGroupMemberRole RPC

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -93,6 +93,8 @@ service FrontierService {
 
   rpc RemoveGroupUser(RemoveGroupUserRequest) returns (RemoveGroupUserResponse) {}
 
+  rpc SetGroupMemberRole(SetGroupMemberRoleRequest) returns (SetGroupMemberRoleResponse) {}
+
   rpc EnableGroup(EnableGroupRequest) returns (EnableGroupResponse) {}
 
   rpc DisableGroup(DisableGroupRequest) returns (DisableGroupResponse) {}
@@ -2175,6 +2177,16 @@ message RemoveGroupUserRequest {
 }
 
 message RemoveGroupUserResponse {}
+
+message SetGroupMemberRoleRequest {
+  string group_id = 1 [(buf.validate.field).string.uuid = true];
+  string org_id = 2 [(buf.validate.field).string.uuid = true];
+  string principal_id = 3 [(buf.validate.field).string.uuid = true];
+  string principal_type = 4 [(buf.validate.field).string.min_len = 1];
+  string role_id = 5 [(buf.validate.field).string.uuid = true];
+}
+
+message SetGroupMemberRoleResponse {}
 
 message DeleteRelationRequest {
   reserved 3;


### PR DESCRIPTION
## Summary

- Adds `SetGroupMemberRole` RPC + request/response messages to `FrontierService`, mirroring `SetOrganizationMemberRole`.
- Lets callers change an existing group member's role with an explicit `role_id` and `principal_type` (currently `app/user`; field is generic so future principal types can be supported without a proto change).
- `AddGroupUsers` is left untouched for backward compatibility — it will be migrated and eventually removed in a follow-up.

## Why

Today the group membership APIs hardcode role assignments (`AddGroupUsers` → member, group creation → owner) and update policies and direct SpiceDB relations separately. A dedicated `SetGroupMemberRole` is needed so the frontier implementation can change a member's role atomically and keep policy + direct relation in sync — fixing the leaky-relation bug at the group layer (see raystack/frontier#1478).

## Test plan

- [x] `buf lint`
- [x] `buf build`
- [x] `buf breaking --against main` (wire-compatible)