### PR TITLE
feat(frontier): add optional relation field to RemovePlatformUserRequest

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -358,6 +358,10 @@ message ListPlatformUsersResponse {
 message RemovePlatformUserRequest {
   string user_id = 1;
   string serviceuser_id = 2;
+
+  // relation scopes the removal to a single platform relation (admin or member).
+  // When empty, all platform relations of the principal are removed.
+  string relation = 3;
 }
 
 message RemovePlatformUserResponse {}


### PR DESCRIPTION
## What

Adds an optional `relation` field (field number 3) to `RemovePlatformUserRequest` in `raystack/frontier/v1beta1/admin.proto`.

```proto
message RemovePlatformUserRequest {
  string user_id = 1;
  string serviceuser_id = 2;

  // relation scopes the removal to a single platform relation (admin or member).
  // When empty, all platform relations of the principal are removed.
  string relation = 3;
}
```

Unlike the sibling `AddPlatformUserRequest.relation`, this field is **optional** (not `REQUIRED`): an empty `relation` must preserve today's behavior of removing the principal entirely.

## Why

This unblocks relation-selective platform-user removal in Frontier. Today Frontier's `RemovePlatformUser` strips both the `admin` (superuser) and `member` (check) platform relations because the request has no `relation` field, so there is no way to demote an admin down to member or remove just one relation via the API.

Adding this optional field lets callers target a single relation (`admin` or `member`) while the empty default stays 100% backward compatible. It is a prerequisite for a declarative platform-user reconciler in Frontier, which must converge `(principal, relation)` pairs precisely. Frontier regenerates its Go stubs from this repo, so the field must land here first.

## Backward compatibility

- New optional `proto3` scalar field, additive only. Wire-compatible.
- `buf lint` and `buf format` pass.