### PR TITLE
refactor(frontier): remove unused ListOrganizationsByDomain messages

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1702,17 +1702,6 @@ message ListOrganizationDomainsResponse {
   repeated Domain domains = 1;
 }
 
-message ListOrganizationsByDomainRequest {
-  string name = 1 [
-    (buf.validate.field).string.min_len = 3,
-    (google.api.field_behavior) = REQUIRED
-  ];
-}
-
-message ListOrganizationsByDomainResponse {
-  repeated Organization organizations = 1;
-}
-
 message JoinOrganizationRequest {
   string org_id = 1 [(buf.validate.field).string.min_len = 3];
 }


### PR DESCRIPTION
`FrontierService` declares no rpc that uses `ListOrganizationsByDomainRequest` or `ListOrganizationsByDomainResponse`. Nothing else in this repo references these messages. This removes the two message declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)