### PR TITLE
feat(frontier): add upper bounds to pagination page_size and rql limit fields

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -174,7 +174,10 @@ service AdminService {
 message ListAllUsersRequest {
   int32 page_size = 1 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
-    int32: {gte: 1}
+    int32: {
+      gte: 1
+      lte: 5000
+    }
   }];
   int32 page_num = 2 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
@@ -212,7 +215,10 @@ message ListAllOrganizationsRequest {
   string state = 2;
   int32 page_size = 3 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
-    int32: {gte: 1}
+    int32: {
+      gte: 1
+      lte: 5000
+    }
   }];
   int32 page_num = 4 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
@@ -395,7 +401,10 @@ message ListAllInvoicesRequest {
   string org_id = 1;
   int32 page_size = 2 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
-    int32: {gte: 1}
+    int32: {
+      gte: 1
+      lte: 5000
+    }
   }];
   int32 page_num = 3 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1078,7 +1078,10 @@ message UserRequestBody {
 message ListUsersRequest {
   int32 page_size = 1 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
-    int32: {gte: 1}
+    int32: {
+      gte: 1
+      lte: 5000
+    }
   }];
   int32 page_num = 2 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
@@ -1151,7 +1154,10 @@ message ListProjectsByCurrentUserRequest {
 
   int32 page_size = 5 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
-    int32: {gte: 1}
+    int32: {
+      gte: 1
+      lte: 5000
+    }
   }];
   int32 page_num = 6 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
@@ -1556,7 +1562,10 @@ message ListOrganizationsRequest {
   string state = 2;
   int32 page_size = 3 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE
-    int32: {gte: 1}
+    int32: {
+      gte: 1
+      lte: 5000
+    }
   }];
   int32 page_num = 4 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE

--- a/raystack/frontier/v1beta1/models.proto
+++ b/raystack/frontier/v1beta1/models.proto
@@ -871,7 +871,7 @@ message RQLRequest {
   repeated RQLFilter filters = 1;
   repeated string group_by = 2;
   uint32 offset = 3;
-  uint32 limit = 4;
+  uint32 limit = 4 [(buf.validate.field).uint32.lte = 5000];
   string search = 5;
   repeated RQLSort sort = 6;
 }


### PR DESCRIPTION
Adds a maximum bound of 5000, using `buf.validate` `lte` rules, to:

- `page_size` in `ListUsersRequest`, `ListProjectsByCurrentUserRequest`, `ListOrganizationsRequest` (frontier.proto)
- `page_size` in `ListAllUsersRequest`, `ListAllOrganizationsRequest`, `ListAllInvoicesRequest` (admin.proto)
- `limit` in the shared `RQLRequest` (models.proto)

Zero still means unset and keeps server-side defaults. Values from 1 to 5000 are accepted as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)