### PR TITLE
feat: add state field to billing plan model and request body

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -882,6 +882,8 @@ message PlanRequestBody {
   int64 on_start_credits = 6;
   int64 trial_days = 7;
 
+  string state = 8;
+
   google.protobuf.Struct metadata = 20;
 }
 

--- a/raystack/frontier/v1beta1/models.proto
+++ b/raystack/frontier/v1beta1/models.proto
@@ -548,6 +548,8 @@ message Plan {
   int64 on_start_credits = 7 [(buf.validate.field).int64 = {gte: 0}];
   int64 trial_days = 8 [(buf.validate.field).int64 = {gte: 0}];
 
+  string state = 9;
+
   google.protobuf.Struct metadata = 20;
   google.protobuf.Timestamp created_at = 21;
   google.protobuf.Timestamp updated_at = 22;


### PR DESCRIPTION
## What

Add a `state` field ("active" or "inactive") to the billing `Plan` model and to `PlanRequestBody`.

## Why

The plan config file that the boot loader reads can already set a plan's state, and the loader applies it, so a plan can be marked inactive to retire it. The API could not carry that field. `PlanRequestBody` had no `state`, so `CreatePlan` and `UpdatePlan` could not set it, and the `Plan` message had no `state`, so a read never returned it.

This blocks managing plans through the API the same way the boot file does. A tool that reads the current plans and writes them back cannot keep a plan inactive, because it can neither read the state nor set it.

## Change

- `Plan` model: add `string state = 9` so a read returns the plan's state, matching how `Product` and `Price` already expose `state`.
- `PlanRequestBody`: add `string state = 8` so create and update can set it.

Both are new fields, so the change is backward compatible. `buf lint`, `buf build`, and `buf breaking` all pass.