### PR TITLE
fix: allow an empty interval on a billing price

### DIFF
--- a/raystack/frontier/v1beta1/models.proto
+++ b/raystack/frontier/v1beta1/models.proto
@@ -611,14 +611,18 @@ message Price {
   string provider_id = 3;
   string name = 4;
 
-  // known intervals are "day", "week", "month", and "year"
-  string interval = 6 [(buf.validate.field).string = {
-    in: [
-      "day",
-      "week",
-      "month",
-      "year"
-    ]
+  // known intervals are "day", "week", "month", and "year"; an empty interval
+  // means a one-time price with no recurring billing
+  string interval = 6 [(buf.validate.field) = {
+    ignore: IGNORE_IF_ZERO_VALUE
+    string: {
+      in: [
+        "day",
+        "week",
+        "month",
+        "year"
+      ]
+    }
   }];
 
   // usage_type known types are "licensed" and "metered"


### PR DESCRIPTION
## What

Allow an empty `interval` on a billing `Price`. The validation now ignores a zero value, matching how `usage_type` and `billing_scheme` already behave.

## Why

A one-time price has no recurring interval. The billing service already creates such prices (the plan boot loader does this today), and `CreatePrice` only builds the recurring block when an interval is set. But the API rejected an empty interval, so a one-time price could not be created or updated through `CreateProduct` / `UpdateProduct`. This makes the API accept what the service already supports.

Relaxing a validation rule is backward compatible. `buf lint`, `buf build`, and `buf breaking` all pass.