### PR TITLE
chore!: remove plan_id from frontier ProductRequestBody

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -753,12 +753,12 @@ message GetCheckoutResponse {
 }
 
 message ProductRequestBody {
-  reserved 7;
+  reserved 4, 7;
+  reserved "plan_id";
 
   string name = 1 [(buf.validate.field).string.min_len = 3];
   string title = 2;
   string description = 3;
-  string plan_id = 4;
   repeated Price prices = 5;
   string behavior = 8 [(buf.validate.field) = {
     ignore: IGNORE_IF_ZERO_VALUE


### PR DESCRIPTION
## What

Remove `plan_id` from `ProductRequestBody` and reserve the field number (4) and the name, so it cannot be reused with a different meaning.

`ProductRequestBody` is shared by `CreateProduct` and `UpdateProduct`.

## Why

Nothing links a product to a plan through this field in practice. Frontier links products to plans from the plan side: `UpsertPlans` creates the product and then calls `AddPlan`, after checking the product has an active price at the plan's interval.

The request-body `plan_id` was a way around that check. Creating a product with a `plan_id` writes the link straight to the database and skips the matching-price check, so you could link a product to a plan that has no valid price for its interval. `UpdateProduct` already ignored the field.

Removing it makes plan membership owned solely by the plan side, and drops a dead field from `UpdateProduct` at the same time.

## Breaking change

This removes a public field. The number and name are reserved so the wire and JSON stay safe. Frontier's handler is updated to stop reading it in a matching PR.
