### PR TITLE
feat(frontier)!: move CreatePlan and UpdatePlan to AdminService and add ListAllPlans

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -440,7 +440,13 @@ message ListAllBillingAccountsResponse {
 
 message ListAllPlansRequest {
   // filter by plan state, e.g. "active" or "disabled". an empty value returns all plans
-  string state = 1;
+  string state = 1 [(buf.validate.field).string = {
+    in: [
+      "",
+      "active",
+      "disabled"
+    ]
+  }];
 }
 
 message ListAllPlansResponse {
@@ -462,10 +468,16 @@ message PlanRequestBody {
       "year"
     ]
   }];
-  int64 on_start_credits = 6;
-  int64 trial_days = 7;
+  int64 on_start_credits = 6 [(buf.validate.field).int64.gte = 0];
+  int64 trial_days = 7 [(buf.validate.field).int64.gte = 0];
 
-  string state = 8;
+  string state = 8 [(buf.validate.field).string = {
+    in: [
+      "",
+      "active",
+      "disabled"
+    ]
+  }];
 
   google.protobuf.Struct metadata = 20;
 }

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -438,21 +438,6 @@ message ListAllBillingAccountsResponse {
   repeated BillingAccount billing_accounts = 1;
 }
 
-message ListAllPlansRequest {
-  // filter by plan state, e.g. "active" or "disabled". an empty value returns all plans
-  string state = 1 [(buf.validate.field).string = {
-    in: [
-      "",
-      "active",
-      "disabled"
-    ]
-  }];
-}
-
-message ListAllPlansResponse {
-  repeated Plan plans = 1;
-}
-
 message PlanRequestBody {
   string name = 1;
   string title = 2;
@@ -468,12 +453,12 @@ message PlanRequestBody {
       "year"
     ]
   }];
-  int64 on_start_credits = 6 [(buf.validate.field).int64.gte = 0];
-  int64 trial_days = 7 [(buf.validate.field).int64.gte = 0];
+  int64 on_start_credits = 6 [(buf.validate.field).int64 = {gte: 0}];
+  int64 trial_days = 7 [(buf.validate.field).int64 = {gte: 0}];
 
+  // known states are "active" and "disabled"
   string state = 8 [(buf.validate.field).string = {
     in: [
-      "",
       "active",
       "disabled"
     ]
@@ -492,16 +477,55 @@ message CreatePlanResponse {
   Plan plan = 1;
 }
 
+// UpdatePlanRequestBody carries the plan fields UpdatePlan writes. It has no
+// name, interval, or products because UpdatePlan does not change those; a
+// plan's products are managed through CreatePlan's upsert.
+message UpdatePlanRequestBody {
+  string title = 1;
+  string description = 2;
+  int64 on_start_credits = 3 [(buf.validate.field).int64 = {gte: 0}];
+  int64 trial_days = 4 [(buf.validate.field).int64 = {gte: 0}];
+
+  // known states are "active" and "disabled"
+  string state = 5 [(buf.validate.field).string = {
+    in: [
+      "active",
+      "disabled"
+    ]
+  }];
+
+  google.protobuf.Struct metadata = 20;
+}
+
 message UpdatePlanRequest {
   // ID of the plan to update
   string id = 1 [(buf.validate.field).string.min_len = 1];
-  // Plan to update
-  PlanRequestBody body = 2;
+  // field 2 held a PlanRequestBody before UpdatePlan moved to its own body type
+  reserved 2;
+  // Plan fields to write
+  UpdatePlanRequestBody body = 3 [(buf.validate.field).required = true];
 }
 
 message UpdatePlanResponse {
   // Updated plan
   Plan plan = 1;
+}
+
+message ListAllPlansRequest {
+  // filter by plan state. an empty value returns plans in every state
+  string state = 1 [(buf.validate.field) = {
+    ignore: IGNORE_IF_ZERO_VALUE
+    string: {
+      in: [
+        "active",
+        "disabled"
+      ]
+    }
+  }];
+}
+
+message ListAllPlansResponse {
+  repeated Plan plans = 1;
 }
 
 message RevertBillingUsageRequest {

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -117,6 +117,15 @@ service AdminService {
 
   rpc ListAllBillingAccounts(ListAllBillingAccountsRequest) returns (ListAllBillingAccountsResponse) {}
 
+  // Plans
+  rpc CreatePlan(CreatePlanRequest) returns (CreatePlanResponse) {}
+
+  rpc UpdatePlan(UpdatePlanRequest) returns (UpdatePlanResponse) {}
+
+  // ListAllPlans returns every plan, including disabled ones, unlike
+  // FrontierService.ListPlans which returns active plans only.
+  rpc ListAllPlans(ListAllPlansRequest) returns (ListAllPlansResponse) {}
+
   // Usage
   rpc RevertBillingUsage(RevertBillingUsageRequest) returns (RevertBillingUsageResponse) {}
 
@@ -427,6 +436,60 @@ message ListAllBillingAccountsRequest {
 
 message ListAllBillingAccountsResponse {
   repeated BillingAccount billing_accounts = 1;
+}
+
+message ListAllPlansRequest {
+  // filter by plan state, e.g. "active" or "disabled". an empty value returns all plans
+  string state = 1;
+}
+
+message ListAllPlansResponse {
+  repeated Plan plans = 1;
+}
+
+message PlanRequestBody {
+  string name = 1;
+  string title = 2;
+  string description = 3;
+
+  repeated Product products = 4;
+  // known intervals are "day", "week", "month", and "year"
+  string interval = 5 [(buf.validate.field).string = {
+    in: [
+      "day",
+      "week",
+      "month",
+      "year"
+    ]
+  }];
+  int64 on_start_credits = 6;
+  int64 trial_days = 7;
+
+  string state = 8;
+
+  google.protobuf.Struct metadata = 20;
+}
+
+message CreatePlanRequest {
+  // Plan to create
+  PlanRequestBody body = 1 [(buf.validate.field).required = true];
+}
+
+message CreatePlanResponse {
+  // Created plan
+  Plan plan = 1;
+}
+
+message UpdatePlanRequest {
+  // ID of the plan to update
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+  // Plan to update
+  PlanRequestBody body = 2;
+}
+
+message UpdatePlanResponse {
+  // Updated plan
+  Plan plan = 1;
 }
 
 message RevertBillingUsageRequest {

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -122,7 +122,7 @@ service AdminService {
 
   rpc UpdatePlan(UpdatePlanRequest) returns (UpdatePlanResponse) {}
 
-  // ListAllPlans returns every plan, including disabled ones, unlike
+  // ListAllPlans returns every plan, including inactive ones, unlike
   // FrontierService.ListPlans which returns active plans only.
   rpc ListAllPlans(ListAllPlansRequest) returns (ListAllPlansResponse) {}
 
@@ -456,11 +456,11 @@ message PlanRequestBody {
   int64 on_start_credits = 6 [(buf.validate.field).int64 = {gte: 0}];
   int64 trial_days = 7 [(buf.validate.field).int64 = {gte: 0}];
 
-  // known states are "active" and "disabled"
+  // known states are "active" and "inactive"
   string state = 8 [(buf.validate.field).string = {
     in: [
       "active",
-      "disabled"
+      "inactive"
     ]
   }];
 
@@ -479,18 +479,19 @@ message CreatePlanResponse {
 
 // UpdatePlanRequestBody carries the plan fields UpdatePlan writes. It has no
 // name, interval, or products because UpdatePlan does not change those; a
-// plan's products are managed through CreatePlan's upsert.
+// plan's products are managed through CreatePlan's upsert. UpdatePlan is a full
+// write of these fields: an omitted field is cleared, not left unchanged.
 message UpdatePlanRequestBody {
   string title = 1;
   string description = 2;
   int64 on_start_credits = 3 [(buf.validate.field).int64 = {gte: 0}];
   int64 trial_days = 4 [(buf.validate.field).int64 = {gte: 0}];
 
-  // known states are "active" and "disabled"
+  // known states are "active" and "inactive"
   string state = 5 [(buf.validate.field).string = {
     in: [
       "active",
-      "disabled"
+      "inactive"
     ]
   }];
 
@@ -498,7 +499,7 @@ message UpdatePlanRequestBody {
 }
 
 message UpdatePlanRequest {
-  // ID of the plan to update
+  // ID or name of the plan to update
   string id = 1 [(buf.validate.field).string.min_len = 1];
   // field 2 held a PlanRequestBody before UpdatePlan moved to its own body type
   reserved 2;
@@ -518,7 +519,7 @@ message ListAllPlansRequest {
     string: {
       in: [
         "active",
-        "disabled"
+        "inactive"
       ]
     }
   }];

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -339,13 +339,9 @@ service FrontierService {
   rpc ListFeatures(ListFeaturesRequest) returns (ListFeaturesResponse) {}
 
   // Plans
-  rpc CreatePlan(CreatePlanRequest) returns (CreatePlanResponse) {}
-
   rpc ListPlans(ListPlansRequest) returns (ListPlansResponse) {}
 
   rpc GetPlan(GetPlanRequest) returns (GetPlanResponse) {}
-
-  rpc UpdatePlan(UpdatePlanRequest) returns (UpdatePlanResponse) {}
 
   // Checkout
   rpc CreateCheckout(CreateCheckoutRequest) returns (CreateCheckoutResponse) {}
@@ -864,39 +860,6 @@ message ListFeaturesResponse {
   repeated Feature features = 1;
 }
 
-message PlanRequestBody {
-  string name = 1;
-  string title = 2;
-  string description = 3;
-
-  repeated Product products = 4;
-  // known intervals are "day", "week", "month", and "year"
-  string interval = 5 [(buf.validate.field).string = {
-    in: [
-      "day",
-      "week",
-      "month",
-      "year"
-    ]
-  }];
-  int64 on_start_credits = 6;
-  int64 trial_days = 7;
-
-  string state = 8;
-
-  google.protobuf.Struct metadata = 20;
-}
-
-message CreatePlanRequest {
-  // Plan to create
-  PlanRequestBody body = 1 [(buf.validate.field).required = true];
-}
-
-message CreatePlanResponse {
-  // Created plan
-  Plan plan = 1;
-}
-
 message GetPlanRequest {
   // ID of the plan to get
   string id = 1 [(buf.validate.field).string.min_len = 1];
@@ -904,18 +867,6 @@ message GetPlanRequest {
 
 message GetPlanResponse {
   // Plan
-  Plan plan = 1;
-}
-
-message UpdatePlanRequest {
-  // ID of the plan to update
-  string id = 1 [(buf.validate.field).string.min_len = 1];
-  // Plan to update
-  PlanRequestBody body = 2;
-}
-
-message UpdatePlanResponse {
-  // Updated plan
   Plan plan = 1;
 }
 


### PR DESCRIPTION
## What

Move the plan write APIs to `AdminService` and add a new `ListAllPlans` API.

- `CreatePlan` and `UpdatePlan` move from `FrontierService` to `AdminService`.
- New `ListAllPlans` on `AdminService`. It returns every plan, including inactive ones. An empty state returns all plans; a set state filters to it.
- The plan write messages (`PlanRequestBody`, `CreatePlanRequest`, `CreatePlanResponse`, `UpdatePlanRequest`, `UpdatePlanResponse`) move from `frontier.proto` into `admin.proto`, so `admin.proto` does not import `frontier.proto`.
- `UpdatePlan` takes a new `UpdatePlanRequestBody` (title, description, on_start_credits, trial_days, state, metadata). It has no name, interval, or products because UpdatePlan does not change those. It is a full write: an omitted field is cleared, not left unchanged. `UpdatePlanRequest.body` is required.
- `ListPlans` and `GetPlan`, and their messages, stay on `FrontierService` in `frontier.proto`. `ListPlans` still returns active plans only.
- Validation: plan `state` must be `active` or `inactive` on the write bodies (empty is rejected, so state is required); the `ListAllPlans` filter allows an empty state to mean "all"; `on_start_credits` and `trial_days` must be zero or more.

## Why

Plan writes are admin only. Today they sit on `FrontierService` and are gated to platform superusers by the server. Moving them to `AdminService` puts them on the admin surface where they belong.

The billing reconcile flow in Frontier needs to read every plan for export, including inactive ones. `ListPlans` returns active plans only, so it cannot see an inactive plan. `ListAllPlans` fills that gap.

The state values (`active` / `inactive`) follow frontier's billing convention: prices use `PriceStateInactive = "inactive"` (`billing/product/product.go`), and no billing code uses `disabled`.

## Breaking change and migration

`CreatePlan` and `UpdatePlan` are removed from `FrontierService`.

- gRPC and Connect callers must switch the method path from `FrontierService` to `AdminService`. The old paths return `UNIMPLEMENTED`.
- Message full names are unchanged (same package), so message wire and JSON stay compatible. But `UpdatePlanRequest.body` changed from `PlanRequestBody` to the new `UpdatePlanRequestBody` on a new field number (field 2 is reserved, body is now field 3). This is wire-safe, but the Go type of `UpdatePlanRequest.Body` changes, which is a compile break for Go callers of UpdatePlan.
- Per-file codegen (TypeScript protobuf-es, Python) will see the moved messages relocate from the frontier module to the admin module, so those imports must change.
- A caller that only re-points its URL to `AdminService` but keeps its old JSON body will not get an error for the fields that no longer exist on the update body: the JSON codec discards unknown fields, so `name`, `interval`, and `products` are silently dropped from an `UpdatePlan` body.
- A `CreatePlan` or `UpdatePlan` caller that used to omit `state` (the server defaulted it to `active`) now gets `INVALID_ARGUMENT`, because `state` is validated to `active`/`inactive`.
- `buf breaking` passes at the WIRE level; the service surface change above is intentional and not covered by that gate.

## Testing

- `buf build`, `buf lint`, and `buf breaking` against main all pass.
