### PR TITLE
feat(frontier): add acknowledge_token_forfeit to DeleteOrganizationRequest

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1744,6 +1744,11 @@ message DisableOrganizationResponse {}
 
 message DeleteOrganizationRequest {
   string id = 1;
+  // Set to true to confirm that any unused prepaid tokens on the
+  // organization's billing account may be forfeited by this delete.
+  // If the account has unused tokens and this is false, the request
+  // fails with a failed_precondition error listing the amount at stake.
+  bool acknowledge_token_forfeit = 2;
 }
 
 message DeleteOrganizationResponse {}


### PR DESCRIPTION
## What

Adds a `bool acknowledge_token_forfeit` field to `DeleteOrganizationRequest`.

## Why

Part of raystack/frontier#1837. Deleting an organization can forfeit unused prepaid tokens on its billing account. A UI confirmation popup is not enough on its own — the API is public (SDKs, scripts, curl), so the server can only enforce the consent if it arrives inside the request.

Planned behavior in frontier:

- If the org has unused prepaid tokens and the flag is not set, the delete fails with a `failed_precondition` error saying how many tokens would be lost.
- If the flag is set, the delete proceeds and the forfeited amount is written to the audit record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)