### PR TITLE
fix(frontier): allow omitted plan state

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -457,11 +457,14 @@ message PlanRequestBody {
   int64 trial_days = 7 [(buf.validate.field).int64 = {gte: 0}];
 
   // known states are "active" and "inactive"
-  string state = 8 [(buf.validate.field).string = {
-    in: [
-      "active",
-      "inactive"
-    ]
+  string state = 8 [(buf.validate.field) = {
+    ignore: IGNORE_IF_ZERO_VALUE
+    string: {
+      in: [
+        "active",
+        "inactive"
+      ]
+    }
   }];
 
   google.protobuf.Struct metadata = 20;


### PR DESCRIPTION
## Problem

`PlanRequestBody.state` is currently validated as either `active` or `inactive`.
Because the zero value (`""`) is not ignored, `CreatePlan` requests that omit
`state` are rejected before reaching Frontier's create logic.

Frontier already defaults an omitted plan state to `active` when creating a
plan.

## Change

Update `PlanRequestBody.state` validation to ignore the zero value while
continuing to validate non-empty values against `active` and `inactive`.

## Context

Related to raystack/frontier#1853