### PR TITLE
feat(frontier): add CheckOrganizationDelete to report org delete blockers

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1762,10 +1762,13 @@ message CheckOrganizationDeleteResponse {
     // machine-readable reason, e.g. ACTIVE_SUBSCRIPTION, UNPAID_INVOICE,
     // NEGATIVE_TOKEN_BALANCE
     string type = 1;
-    // id of the blocking entity, e.g. a subscription or an invoice id
+    // id of the blocking entity
     string subject = 2;
     // what blocks the delete and what the caller can do about it
     string message = 3;
+    // what kind of entity the subject id refers to, e.g.
+    // billing_subscription, billing_invoice, billing_account
+    string subject_type = 4;
   }
   // true when nothing blocks the delete right now
   bool can_delete = 1;

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -164,6 +164,11 @@ service FrontierService {
 
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {}
 
+  // CheckOrganizationDelete reports everything that currently blocks deleting
+  // the organization, without changing anything. An empty blocker list means
+  // DeleteOrganization would proceed right now.
+  rpc CheckOrganizationDelete(CheckOrganizationDeleteRequest) returns (CheckOrganizationDeleteResponse) {}
+
   // Projects
   rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse) {}
 
@@ -1747,6 +1752,26 @@ message DeleteOrganizationRequest {
 }
 
 message DeleteOrganizationResponse {}
+
+message CheckOrganizationDeleteRequest {
+  string id = 1;
+}
+
+message CheckOrganizationDeleteResponse {
+  message Blocker {
+    // machine-readable reason, e.g. ACTIVE_SUBSCRIPTION, UNPAID_INVOICE,
+    // NEGATIVE_TOKEN_BALANCE
+    string type = 1;
+    // id of the blocking entity, e.g. a subscription or an invoice id
+    string subject = 2;
+    // what blocks the delete and what the caller can do about it
+    string message = 3;
+  }
+  // true when nothing blocks the delete right now
+  bool can_delete = 1;
+  // every reason the delete would be refused; empty when can_delete is true
+  repeated Blocker blockers = 2;
+}
 
 message GetOrganizationKycRequest {
   string org_id = 1;


### PR DESCRIPTION
Adds a read-only RPC to FrontierService:

```proto
rpc CheckOrganizationDelete(CheckOrganizationDeleteRequest) returns (CheckOrganizationDeleteResponse) {}
```

`DeleteOrganization` refuses with `failed_precondition` while anything blocks the delete (an active subscription on a paid plan, an unpaid invoice, a negative token balance). Clients need to know that state before the user clicks delete — for example to grey out the delete button and say why. This RPC returns the same blocker list without changing anything; an empty list means the delete would proceed right now.

Each blocker carries:

- `type` — the machine-readable reason (`ACTIVE_SUBSCRIPTION`, `UNPAID_INVOICE`, `NEGATIVE_TOKEN_BALANCE`)
- `subject` — the id of the blocking entity
- `subject_type` — what kind of entity that id refers to (`billing_subscription`, `billing_invoice`, `billing_account`)
- `message` — what blocks the delete and what the caller can do about it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
