### PR TITLE
chore!: remove deprecated name and namespace fields from frontier permission protos

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -293,14 +293,13 @@ message DeleteRoleRequest {
 message DeleteRoleResponse {}
 
 message PermissionRequestBody {
-  string name = 1 [deprecated = true];
-  // namespace should be in service/resource format
-  string namespace = 2 [deprecated = true];
+  reserved 1, 2;
+  reserved "name", "namespace";
+
   google.protobuf.Struct metadata = 3;
   string title = 4;
 
   // key is composed of three parts, 'service.resource.verb'. Where 'service.resource' works as a namespace for the 'verb'.
-  // Use this instead of using name and namespace fields
   string key = 5;
 }
 

--- a/raystack/frontier/v1beta1/models.proto
+++ b/raystack/frontier/v1beta1/models.proto
@@ -154,19 +154,15 @@ message Relation {
 }
 
 message Permission {
+  reserved 2, 6;
+  reserved "name", "namespace";
+
   string id = 1;
-  string name = 2 [
-    (buf.validate.field).string = {
-      min_len: 2
-      pattern: "^[A-Za-z0-9]+$"
-    },
-    deprecated = true
-  ];
   string title = 3;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp updated_at = 5;
-  string namespace = 6 [deprecated = true];
   google.protobuf.Struct metadata = 7;
+  // key is composed of three parts, 'service.resource.verb'. Where 'service.resource' works as a namespace for the 'verb'.
   string key = 8;
 }
 


### PR DESCRIPTION
## Summary
Removes the deprecated `name` and `namespace` fields from the frontier `Permission` message (`models.proto`) and `PermissionRequestBody` (`admin.proto`). The `key` field (`service.resource.verb`) is the sole way to express a permission's identity in both requests and responses. Final proto step of raystack/frontier#1782.

## Why this is safe
- frontier stopped reading the request fields (raystack/frontier#1885) and no longer needs the response fields since `key` round-trips losslessly (raystack/frontier#1887).
- Field numbers and names are reserved, so they cannot be reused and `buf breaking` (WIRE) passes.
- On the wire, proto3 ignores unknown fields: an old client that still sends `name`/`namespace` gets the same behavior it gets today (the server no longer reads them). Clients that read the removed response fields must move to `key`; frontier will call this out in its release notes.

## Changes
- `raystack/frontier/v1beta1/models.proto`: drop `Permission.name` (2) and `Permission.namespace` (6); reserve the numbers and names; document `key`.
- `raystack/frontier/v1beta1/admin.proto`: drop `PermissionRequestBody.name` (1) and `.namespace` (2); reserve the numbers and names.

## Test Plan
- [x] `buf lint` passes
- [x] `buf breaking --against main` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)